### PR TITLE
Make group status deletion reliable

### DIFF
--- a/src/Commands/Admin/antigroupstatus.js
+++ b/src/Commands/Admin/antigroupstatus.js
@@ -1,4 +1,5 @@
 const { createAntiMessageModeration } = require('../../Plugin/antiMessageModeration');
+const { normalizeJid } = require('../../Plugin/identityUtils');
 
 const NESTED_MESSAGE_KEYS = [
     'ephemeralMessage',
@@ -19,6 +20,97 @@ function isGroupStatusMessage(message) {
     return NESTED_MESSAGE_KEYS.some(key => isGroupStatusMessage(message[key]?.message));
 }
 
+function isUserJid(jid = '') {
+    const normalized = normalizeJid(jid);
+    return normalized.endsWith('@s.whatsapp.net') || normalized.endsWith('@lid');
+}
+
+function participantIdentities(participant = {}) {
+    return [participant.phoneNumber, participant.id, participant.lid]
+        .filter(isUserJid)
+        .map(normalizeJid);
+}
+
+async function buildAuthorCandidates(sock, m, mek, context = {}) {
+    const rawKey = mek?.key || m.key || {};
+    const candidates = [
+        context.senderJid,
+        rawKey.participantAlt,
+        m.key?.participantAlt,
+        rawKey.participant,
+        m.key?.participant,
+        m.sender,
+        ...(context.senderRecord ? participantIdentities(context.senderRecord) : []),
+    ].filter(isUserJid).map(normalizeJid);
+
+    const mapper = sock?.signalRepository?.lidMapping;
+    for (const jid of [...candidates]) {
+        try {
+            if (jid.endsWith('@lid') && mapper?.getPNForLID) {
+                const pn = await mapper.getPNForLID(jid);
+                if (isUserJid(pn)) candidates.push(normalizeJid(pn));
+            } else if (jid.endsWith('@s.whatsapp.net') && mapper?.getLIDForPN) {
+                const lid = await mapper.getLIDForPN(jid);
+                if (isUserJid(lid)) candidates.push(normalizeJid(lid));
+            }
+        } catch {}
+    }
+
+    return [...new Set(candidates)].sort((a, b) => {
+        const aPhone = a.endsWith('@s.whatsapp.net') ? 0 : 1;
+        const bPhone = b.endsWith('@s.whatsapp.net') ? 0 : 1;
+        return aPhone - bPhone;
+    });
+}
+
+function buildDeleteKeys(chat, messageId, authors, rawKey = {}) {
+    const keys = authors.map(participant => ({
+        remoteJid: chat,
+        fromMe: false,
+        id: messageId,
+        participant,
+    }));
+    if (rawKey?.id) keys.push({ ...rawKey, remoteJid: chat, fromMe: false });
+
+    const seen = new Set();
+    return keys.filter(key => {
+        const signature = `${key.remoteJid}|${key.id}|${key.participant || ''}|${key.participantAlt || ''}`;
+        if (!key.id || seen.has(signature)) return false;
+        seen.add(signature);
+        return true;
+    });
+}
+
+async function deleteGroupStatus(sock, m, mek, context = {}) {
+    const rawKey = mek?.key || m.key || {};
+    const authors = await buildAuthorCandidates(sock, m, mek, context);
+    const keys = buildDeleteKeys(m.chat, rawKey.id || m.key?.id, authors, rawKey);
+    const failures = [];
+
+    for (const key of keys) {
+        const methods = [];
+        if (typeof sock.deleteGroupStatus === 'function') {
+            methods.push(() => sock.deleteGroupStatus(m.chat, key));
+        }
+        methods.push(() => sock.sendMessage(m.chat, { delete: key }));
+
+        for (const method of methods) {
+            try {
+                await method();
+                return key;
+            } catch (error) {
+                failures.push({
+                    participantType: key.participant?.endsWith('@lid') ? 'lid' : 'phone',
+                    message: error?.message || String(error),
+                });
+            }
+        }
+    }
+
+    console.error('[ANTIGROUPSTATUS REVOKE ATTEMPTS]', failures);
+    throw new Error(`WhatsApp rejected ${failures.length} group-status revoke attempt(s)`);
+}
+
 const plugin = createAntiMessageModeration({
     command: 'antigroupstatus',
     aliases: ['antigs', 'ags'],
@@ -28,15 +120,13 @@ const plugin = createAntiMessageModeration({
     warningDatabaseName: 'antigroupstatus_warns.json',
     detector: isGroupStatusMessage,
     violationLabel: 'group-status posts',
-    deleteMessage: async (sock, m, mek) => {
-        if (typeof sock.deleteGroupStatus !== 'function') {
-            throw new Error('deleteGroupStatus is unavailable in this Baileys build');
-        }
-        await sock.deleteGroupStatus(m.chat, mek?.key || m.key);
-    }
+    deleteMessage: deleteGroupStatus
 });
 
 plugin.handleAntiGroupStatus = plugin.handleModeration;
 plugin.isGroupStatusMessage = isGroupStatusMessage;
+plugin.buildAuthorCandidates = buildAuthorCandidates;
+plugin.buildDeleteKeys = buildDeleteKeys;
+plugin.deleteGroupStatus = deleteGroupStatus;
 
 module.exports = plugin;

--- a/src/Plugin/antiMessageModeration.js
+++ b/src/Plugin/antiMessageModeration.js
@@ -107,14 +107,21 @@ function createAntiMessageModeration({
                 return false;
             }
 
+            const removalContext = {
+                metadata,
+                senderCandidates,
+                senderJid,
+                senderIdentity,
+                senderRecord,
+            };
             const removeMessage = deleteMessage
-                ? () => deleteMessage(sock, m, mek)
+                ? () => deleteMessage(sock, m, mek, removalContext)
                 : () => sock.sendMessage(m.chat, { delete: m.key });
             try {
                 await removeMessage();
             } catch (error) {
-                await sock.sendMessage(m.chat, { text: `${label} detected prohibited content, but deletion failed. Check the bot's admin permissions.` }, { quoted: mek }).catch(() => {});
-                console.error(`[${command.toUpperCase()} DELETE ERROR]`, error.message);
+                await sock.sendMessage(m.chat, { text: `${label} detected prohibited content, but WhatsApp rejected the delete request. The bot is already recognized as an admin; check the server log for the protocol error.` }, { quoted: mek }).catch(() => {});
+                console.error(`[${command.toUpperCase()} DELETE ERROR]`, error?.stack || error?.message || error);
                 return false;
             }
 

--- a/tests/anti-message-moderation.test.js
+++ b/tests/anti-message-moderation.test.js
@@ -27,26 +27,43 @@ function createMessage(overrides = {}) {
     };
 }
 
-function createSocket({ admin = false, botAdmin = true, deleteFails = false } = {}) {
+function createSocket({ admin = false, botAdmin = true, deleteFails = false, deleteFailures = 0 } = {}) {
     const sent = [];
     const removed = [];
     const deletedStatuses = [];
+    let remainingDeleteFailures = deleteFailures;
     return {
         sent,
         removed,
         deletedStatuses,
         user: { id: '15559999@s.whatsapp.net' },
+        signalRepository: {
+            lidMapping: {
+                getPNForLID: async jid => jid === '999999@lid' ? '15550001@s.whatsapp.net' : null,
+                getLIDForPN: async jid => jid === '15550001@s.whatsapp.net' ? '999999@lid' : null,
+            }
+        },
         groupMetadata: async () => ({
             participants: [
-                { id: '15550001:8@s.whatsapp.net', admin: admin ? 'admin' : null },
+                {
+                    id: '999999@lid',
+                    phoneNumber: '15550001@s.whatsapp.net',
+                    admin: admin ? 'admin' : null
+                },
                 { id: '15559999@s.whatsapp.net', admin: botAdmin ? 'admin' : null }
             ]
         }),
         deleteGroupStatus: async (jid, key) => {
-            if (deleteFails) throw new Error('forbidden');
-            deletedStatuses.push({ jid, key });
+            deletedStatuses.push({ jid, key, method: 'helper' });
+            if (deleteFails || remainingDeleteFailures-- > 0) throw new Error('forbidden');
         },
-        sendMessage: async (jid, content, options) => sent.push({ jid, content, options }),
+        sendMessage: async (jid, content, options) => {
+            if (content.delete) {
+                deletedStatuses.push({ jid, key: content.delete, method: 'standard' });
+                if (deleteFails || remainingDeleteFailures-- > 0) throw new Error('forbidden');
+            }
+            sent.push({ jid, content, options });
+        },
         groupParticipantsUpdate: async (jid, users, action) => removed.push({ jid, users, action })
     };
 }
@@ -98,10 +115,57 @@ test('delete action removes a matching group-status message', async () => {
     });
 
     assert.equal(handled, true);
-    assert.deepEqual(socket.deletedStatuses[0], { jid: message.chat, key: message.key });
+    assert.equal(socket.deletedStatuses[0].jid, message.chat);
+    assert.equal(socket.deletedStatuses[0].key.id, message.key.id);
+    assert.equal(socket.deletedStatuses[0].key.participant, message.sender);
     assert.equal(socket.sent[0].content.mentions[0], message.sender);
     assert.equal(socket.sent[0].options.quoted.message.groupStatusMessageV2 !== undefined, true);
     assert.equal(socket.removed.length, 0);
+});
+
+test('repairs a LID-only status key with the matching phone-number identity', async () => {
+    writeDatabase('antigroupstatus.json', { '123@g.us': { enabled: true, action: 'delete' } });
+    const socket = createSocket();
+    const message = createMessage({
+        sender: '999999@lid',
+        key: { id: 'lid-status', remoteJid: '123@g.us', fromMe: false, participant: '999999@lid' }
+    });
+
+    const handled = await groupStatus.handleAntiGroupStatus(socket, message, {
+        key: message.key,
+        message: { groupStatusMessageV2: { message: { conversation: 'status' } } }
+    });
+
+    assert.equal(handled, true);
+    assert.equal(socket.deletedStatuses[0].key.participant, '15550001@s.whatsapp.net');
+});
+
+test('falls back from the fork helper to the standard Baileys revoke path', async () => {
+    const socket = createSocket({ deleteFailures: 1 });
+    const message = createMessage();
+    const deletedKey = await groupStatus.deleteGroupStatus(socket, message, {
+        key: { ...message.key, participant: message.sender }
+    }, {
+        senderJid: message.sender,
+        senderRecord: { id: '999999@lid', phoneNumber: message.sender }
+    });
+
+    assert.equal(deletedKey.participant, message.sender);
+    assert.equal(socket.deletedStatuses[0].method, 'helper');
+    assert.equal(socket.deletedStatuses[1].method, 'standard');
+});
+
+test('builds deduplicated phone-first revoke keys and retains the raw key', () => {
+    const rawKey = { id: 'status-key', remoteJid: '123@g.us', participant: '999999@lid' };
+    const keys = groupStatus.buildDeleteKeys('123@g.us', rawKey.id, [
+        '999999@lid',
+        '15550001@s.whatsapp.net',
+        '15550001@s.whatsapp.net'
+    ].sort((a, b) => Number(a.endsWith('@lid')) - Number(b.endsWith('@lid'))), rawKey);
+
+    assert.equal(keys[0].participant, '15550001@s.whatsapp.net');
+    assert.equal(keys[1].participant, '999999@lid');
+    assert.equal(keys.length, 2);
 });
 
 test('disabled, from-me, and admin messages are exempt', async () => {
@@ -132,7 +196,7 @@ test('does not claim deletion when group-status deletion fails', async () => {
     });
 
     assert.equal(handled, false);
-    assert.match(socket.sent[0].content.text, /deletion failed/i);
+    assert.match(socket.sent[0].content.text, /WhatsApp rejected the delete request/i);
     assert.doesNotMatch(socket.sent[0].content.text, /was deleted/i);
 });
 
@@ -172,6 +236,8 @@ test('kick action deletes first and immediately removes the sender', async () =>
         message: { groupStatusMessage: { message: { conversation: 'status' } } }
     });
 
-    assert.deepEqual(socket.deletedStatuses[0], { jid: message.chat, key: message.key });
+    assert.equal(socket.deletedStatuses[0].jid, message.chat);
+    assert.equal(socket.deletedStatuses[0].key.id, message.key.id);
+    assert.equal(socket.deletedStatuses[0].key.participant, message.sender);
     assert.equal(socket.removed.length, 1);
 });


### PR DESCRIPTION
## Summary
- apply the final group-status deletion repair on a clean branch created directly from the latest `main`
- rebuild revoke keys using authoritative phone-number and LID identities
- try the fork helper and standard Baileys delete path with deduplicated key variants
- keep admin safeguards, warning/kick behavior, quoted notices, and clean real-number mentions

## Validation
- `npm test` (14 passing tests)
- command loader validation (639 commands loaded)
- `git diff --check`

This supersedes PR #41.