### PR TITLE
feat: improve WhatsApp status moderation and reporting

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
       "license": "MIT",
       "dependencies": {
         "@adiwajshing/keyed-db": "^0.2.4",
-        "@crysnovax/baileys": "^2.6.8",
+        "@crysnovax/baileys": "^2.6.9",
         "@crysnovax/baileys-stable": "^1.0.0",
         "@distube/ytdl-core": "^4.16.12",
         "@faker-js/faker": "^10.3.0",
@@ -25,7 +25,7 @@
         "canvas": "^3.2.3",
         "chalk": "^4.1.2",
         "cheerio": "^1.2.0",
-        "crypto-js": "*",
+        "crypto-js": "latest",
         "docx": "^9.6.1",
         "dotenv": "^17.3.1",
         "express": "^4.22.1",
@@ -285,9 +285,9 @@
       }
     },
     "node_modules/@crysnovax/baileys": {
-      "version": "2.6.8",
-      "resolved": "https://registry.npmjs.org/@crysnovax/baileys/-/baileys-2.6.8.tgz",
-      "integrity": "sha512-9TkG5nvVfCo4w9pBTCYZG60fUTPxj13eG5yjGEkpwjTuSF94TnMxpyzGn8WVg4vX4MdDiwbVvAxw03mxbyCz1A==",
+      "version": "2.6.9",
+      "resolved": "https://registry.npmjs.org/@crysnovax/baileys/-/baileys-2.6.9.tgz",
+      "integrity": "sha512-TVOcd5aG78BFjJWS1NvJTDotWifXRfY01j4d12vVIMH+cx7EKvwHNnPNvzSR2Ee/Skl87pR9ZmZMDnBKj6CTDw==",
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {
@@ -297,6 +297,7 @@
         "async-mutex": "^0.5.0",
         "fflate": "^0.8.2",
         "libsignal": "^6.0.0",
+        "long": "^5.2.3",
         "lru-cache": "^11.2.6",
         "music-metadata": "^11.12.3",
         "p-queue": "^9.1.0",
@@ -9305,4 +9306,3 @@
     }
   }
 }
-

--- a/src/Commands/Admin/antiforward.js
+++ b/src/Commands/Admin/antiforward.js
@@ -1,28 +1,22 @@
 const { createAntiMessageModeration } = require('../../Plugin/antiMessageModeration');
 
-const NESTED_MESSAGE_KEYS = [
-    'ephemeralMessage',
-    'viewOnceMessage',
-    'viewOnceMessageV2',
-    'viewOnceMessageV2Extension',
-    'documentWithCaptionMessage',
-    'groupStatusMessage',
-    'groupStatusMessageV2'
-];
-
 function contextIsForwarded(contextInfo) {
     return contextInfo?.isForwarded === true || Number(contextInfo?.forwardingScore) > 0;
 }
 
-function isForwardedMessage(message) {
+function isForwardedMessage(message, seen = new WeakSet()) {
     if (!message || typeof message !== 'object') return false;
+    if (seen.has(message)) return false;
+    seen.add(message);
 
-    for (const [key, value] of Object.entries(message)) {
-        if (NESTED_MESSAGE_KEYS.includes(key)) continue;
-        if (contextIsForwarded(value?.contextInfo)) return true;
-    }
+    if (contextIsForwarded(message.contextInfo)) return true;
 
-    return NESTED_MESSAGE_KEYS.some(key => isForwardedMessage(message[key]?.message));
+    return Object.values(message).some(value => {
+        if (Array.isArray(value)) {
+            return value.some(item => isForwardedMessage(item, seen));
+        }
+        return isForwardedMessage(value, seen);
+    });
 }
 
 const plugin = createAntiMessageModeration({

--- a/src/Commands/Admin/antigroupstatus.js
+++ b/src/Commands/Admin/antigroupstatus.js
@@ -85,25 +85,24 @@ async function deleteGroupStatus(sock, m, mek, context = {}) {
     const rawKey = mek?.key || m.key || {};
     const authors = await buildAuthorCandidates(sock, m, mek, context);
     const keys = buildDeleteKeys(m.chat, rawKey.id || m.key?.id, authors, rawKey);
+    // Prefer a resolved phone identity when available. The untouched raw key remains
+    // in the candidate list as the final compatibility attempt.
     const failures = [];
+    const hasDedicatedDelete = typeof sock.deleteGroupStatus === 'function';
 
     for (const key of keys) {
-        const methods = [];
-        if (typeof sock.deleteGroupStatus === 'function') {
-            methods.push(() => sock.deleteGroupStatus(m.chat, key));
-        }
-        methods.push(() => sock.sendMessage(m.chat, { delete: key }));
-
-        for (const method of methods) {
-            try {
-                await method();
-                return key;
-            } catch (error) {
-                failures.push({
-                    participantType: key.participant?.endsWith('@lid') ? 'lid' : 'phone',
-                    message: error?.message || String(error),
-                });
+        try {
+            if (hasDedicatedDelete) {
+                await sock.deleteGroupStatus(m.chat, key);
+            } else {
+                await sock.sendMessage(m.chat, { delete: key });
             }
+            return key;
+        } catch (error) {
+            failures.push({
+                participantType: key.participant?.endsWith('@lid') ? 'lid' : 'phone',
+                message: error?.message || String(error),
+            });
         }
     }
 

--- a/src/Commands/Admin/antitag.js
+++ b/src/Commands/Admin/antitag.js
@@ -25,59 +25,44 @@ function saveWarns(data) {
     fs.writeFileSync(WARN_DB_PATH, JSON.stringify(data, null, 2));
 }
 
-// Extract mentions from ALL possible locations in the raw message
-function getMentions(m) {
-    const raw = m.message || {};
-    const mentions = [];
-    let nonJidMentionCount = 0;
+function collectMentionData(value, state, seen = new WeakSet()) {
+    if (!value || typeof value !== 'object' || seen.has(value)) return;
+    seen.add(value);
 
-    // ── Get contextInfo from all possible message types ──
-    const ctxInfo = 
-        raw.extendedTextMessage?.contextInfo ||
-        raw.conversation?.contextInfo ||  // .hidetag sometimes comes as conversation
-        raw.imageMessage?.contextInfo ||
-        raw.videoMessage?.contextInfo ||
-        raw.documentMessage?.contextInfo ||
-        raw.audioMessage?.contextInfo ||
-        raw.stickerMessage?.contextInfo ||
-        m.msg?.contextInfo;
-
-    // ── @all / Mention Everyone detection ──
-    // WhatsApp native @all uses mentionAll flag
-    if (ctxInfo?.mentionAll) {
-        mentions.push('__ALL__');
+    for (const field of ['mentionedJid', 'mentionedJidAlt', 'statusMentions']) {
+        const entries = value[field];
+        if (Array.isArray(entries)) entries.filter(Boolean).forEach(jid => state.mentions.add(jid));
     }
 
-    // ── nonJidMentions: hidetag / @all count (THE KEY FIX!) ──
-    // Your hidetag uses extendedTextMessage with contextInfo.nonJidMentions
-    if (ctxInfo?.nonJidMentions > 0) {
-        nonJidMentionCount = ctxInfo.nonJidMentions;
-        mentions.push('__NONJID__');
+    if (value.mentionAll === true || value.isMentionAll === true) state.hasAllMention = true;
+    const nonJid = value.nonJidMentions;
+    if (Array.isArray(nonJid)) state.nonJidMentionCount += nonJid.length;
+    else if (Number(nonJid) > 0) state.nonJidMentionCount += Number(nonJid);
+
+    for (const child of Object.values(value)) {
+        if (Array.isArray(child)) child.forEach(item => collectMentionData(item, state, seen));
+        else collectMentionData(child, state, seen);
     }
-
-    // ── extendedTextMessage mentionedJid ──
-    const ext = raw.extendedTextMessage;
-    if (ext?.contextInfo?.mentionedJid?.length) {
-        mentions.push(...ext.contextInfo.mentionedJid);
-    }
-
-    // ── imageMessage, videoMessage, etc with caption ──
-    for (const type of ['imageMessage','videoMessage','documentMessage','audioMessage','stickerMessage']) {
-        if (raw[type]?.contextInfo?.mentionedJid?.length) {
-            mentions.push(...raw[type].contextInfo.mentionedJid);
-        }
-    }
-
-    // ── Already serialized by smsg ──
-    if (m.mentionedJid?.length) mentions.push(...m.mentionedJid);
-    if (m.msg?.contextInfo?.mentionedJid?.length) mentions.push(...m.msg.contextInfo.mentionedJid);
-
-    return { mentions: [...new Set(mentions)], nonJidMentionCount };
 }
 
-// Helper to normalize JID
+function getMentions(m) {
+    const state = { mentions: new Set(), nonJidMentionCount: 0, hasAllMention: false };
+    collectMentionData(m.message || {}, state);
+    collectMentionData(m.msg || {}, state);
+    for (const jid of m.mentionedJid || []) state.mentions.add(jid);
+    return { ...state, mentions: [...state.mentions] };
+}
+
 function norm(jid) {
-    return (jid || '').replace(/:\d+@/, '@').replace('@lid', '@s.whatsapp.net');
+    return String(jid || '').replace(/:\d+@/, '@').toLowerCase();
+}
+
+function sameIdentity(first, second) {
+    if (!first || !second) return false;
+    if (norm(first) === norm(second)) return true;
+    const firstNumber = norm(first).endsWith('@s.whatsapp.net') ? norm(first).split('@')[0] : '';
+    const secondNumber = norm(second).endsWith('@s.whatsapp.net') ? norm(second).split('@')[0] : '';
+    return Boolean(firstNumber && secondNumber && firstNumber === secondNumber);
 }
 
 // ── Command ────────────────────────────────────────────────────
@@ -186,10 +171,9 @@ module.exports.handleAntiTag = async function(sock, m) {
         const action     = db[group].action  || 'delete';
         
         // Get ALL mentions from the message
-        const { mentions, nonJidMentionCount } = getMentions(m);
-        const hasAllMention = mentions.includes('__ALL__');
-        const hasNonJid = mentions.includes('__NONJID__');
-        const uniqueMentions = [...new Set(mentions)].filter(m => !m.startsWith('__'));
+        const { mentions, nonJidMentionCount, hasAllMention } = getMentions(m);
+        const hasNonJid = nonJidMentionCount > 0;
+        const uniqueMentions = [...new Set(mentions.map(norm).filter(Boolean))];
         const mentionCount = uniqueMentions.length;
 
         // Get text for hidetag detection
@@ -207,13 +191,15 @@ module.exports.handleAntiTag = async function(sock, m) {
         if (!meta) return;
 
         // Admin exemption - admins are safe
-        const admins = meta.participants.filter(p => p.admin).map(p => norm(p.id));
-        const senderNorm = norm(m.sender);
-        if (admins.includes(senderNorm)) return;
+        const senderCandidates = [m.sender, m.key?.participant, m.key?.participantAlt].filter(Boolean);
+        const senderRecord = meta.participants.find(participant => {
+            const identities = [participant.id, participant.jid, participant.lid, participant.phoneNumber].filter(Boolean);
+            return identities.some(identity => senderCandidates.some(sender => sameIdentity(identity, sender)));
+        });
+        if (senderRecord?.admin) return;
 
-        // Bot exemption - bot is safe
-        const botJid = norm(sock.user?.id || '');
-        if (senderNorm === botJid) return;
+        const botCandidates = [sock.user?.id, sock.user?.lid].filter(Boolean);
+        if (senderCandidates.some(sender => botCandidates.some(bot => sameIdentity(sender, bot)))) return;
 
         const sender = m.sender;
         let triggerReason;
@@ -280,3 +266,6 @@ module.exports.handleAntiTag = async function(sock, m) {
         console.error('[ANTI TAG ERROR]', err.message);
     }
 };
+
+module.exports.getMentions = getMentions;
+module.exports.collectMentionData = collectMentionData;

--- a/src/Commands/Owner/poststory.js
+++ b/src/Commands/Owner/poststory.js
@@ -1,0 +1,96 @@
+const { downloadContentFromMessage } = require('@crysnovax/baileys');
+const { normalizeJid } = require('../../Plugin/identityUtils');
+
+function contactValues(contacts) {
+    if (!contacts) return [];
+    return contacts instanceof Map ? [...contacts.values()] : Object.values(contacts);
+}
+
+async function buildStatusAudience(sock) {
+    const audience = new Set();
+    const contacts = contactValues(sock.store?.contacts);
+    const mapper = sock?.signalRepository?.lidMapping;
+
+    for (const contact of contacts) {
+        const candidates = [contact?.phoneNumber, contact?.id, contact?.jid].filter(Boolean).map(normalizeJid);
+        let phoneJid = candidates.find(jid => jid.endsWith('@s.whatsapp.net'));
+        if (!phoneJid && mapper?.getPNForLID) {
+            const lid = candidates.find(jid => jid.endsWith('@lid'));
+            if (lid) phoneJid = normalizeJid(await mapper.getPNForLID(lid).catch(() => null));
+        }
+        if (phoneJid?.endsWith('@s.whatsapp.net')) audience.add(phoneJid);
+    }
+
+    const self = normalizeJid(sock.user?.id || '');
+    audience.delete(self);
+    return [...audience];
+}
+
+function unwrapMessage(message = {}) {
+    let current = message;
+    for (let depth = 0; depth < 8; depth += 1) {
+        const wrapper = current.ephemeralMessage || current.viewOnceMessage || current.viewOnceMessageV2 || current.viewOnceMessageV2Extension || current.documentWithCaptionMessage;
+        if (!wrapper?.message) break;
+        current = wrapper.message;
+    }
+    return current;
+}
+
+async function downloadQuotedMedia(m) {
+    const quotedMessage = unwrapMessage(
+        m.quoted?.message || m.message?.extendedTextMessage?.contextInfo?.quotedMessage || {}
+    );
+    const type = ['imageMessage', 'videoMessage', 'audioMessage'].find(key => quotedMessage[key]);
+    if (!type) return null;
+    const media = quotedMessage[type];
+    const stream = await downloadContentFromMessage(media, type.replace('Message', ''));
+    const chunks = [];
+    for await (const chunk of stream) chunks.push(chunk);
+    return { type: type.replace('Message', ''), media, buffer: Buffer.concat(chunks) };
+}
+
+module.exports = {
+    name: 'poststory',
+    alias: ['story', 'statuspost'],
+    category: 'Owner',
+    ownerOnly: true,
+    desc: 'Post text or replied media to WhatsApp Status',
+    execute: async (sock, m, { args, reply }) => {
+        try {
+            const statusJidList = await buildStatusAudience(sock);
+            if (!statusJidList.length) return reply('No valid WhatsApp contacts are available for the status audience.');
+
+            const text = args.join(' ').trim();
+            const quoted = await downloadQuotedMedia(m);
+            let content;
+
+            if (!quoted) {
+                if (!text) return reply('Usage: .poststory <text>, or reply to an image, video, or audio message.');
+                content = { status: true, text, backgroundColor: '#FF1FA15A', font: 0, statusJidList };
+            } else if (quoted.type === 'audio') {
+                content = {
+                    status: true,
+                    audio: quoted.buffer,
+                    mimetype: quoted.media.mimetype || 'audio/ogg; codecs=opus',
+                    ptt: Boolean(quoted.media.ptt),
+                    statusJidList,
+                };
+            } else {
+                content = {
+                    status: true,
+                    [quoted.type]: quoted.buffer,
+                    ...(text ? { caption: text } : {}),
+                    statusJidList,
+                };
+            }
+
+            await sock.sendMessage('status@broadcast', content);
+            return reply(`Status posted successfully to ${statusJidList.length} contact${statusJidList.length === 1 ? '' : 's'}.`);
+        } catch (error) {
+            console.error('[POSTSTORY ERROR]', error?.stack || error);
+            return reply(`Failed to post the status: ${error?.message || 'unknown WhatsApp error'}`);
+        }
+    },
+    buildStatusAudience,
+    downloadQuotedMedia,
+};

--- a/src/Commands/Owner/report.js
+++ b/src/Commands/Owner/report.js
@@ -1,0 +1,98 @@
+const { normalizeJid, resolveCommandTarget } = require('../../Plugin/identityUtils');
+
+const PROTECTED_CONTACTS = new Set([
+    '2348077134210@s.whatsapp.net',
+    '120495928283239@lid',
+]);
+const PROTECTED_GROUPS = new Set([
+    '120363425067362165@g.us',
+    '120363396903069780@g.us',
+    '120363426760068896@g.us',
+]);
+const inFlight = new Set();
+
+async function identityVariants(sock, jid) {
+    const variants = new Set([normalizeJid(jid)]);
+    const mapper = sock?.signalRepository?.lidMapping;
+    try {
+        if (jid?.endsWith('@lid') && mapper?.getPNForLID) variants.add(normalizeJid(await mapper.getPNForLID(jid)));
+        if (jid?.endsWith('@s.whatsapp.net') && mapper?.getLIDForPN) variants.add(normalizeJid(await mapper.getLIDForPN(jid)));
+    } catch {}
+    variants.delete('');
+    return variants;
+}
+
+async function isProtectedContact(sock, jid) {
+    const variants = await identityVariants(sock, jid);
+    return [...variants].some(value => PROTECTED_CONTACTS.has(value));
+}
+
+function quotedEvidence(m) {
+    const key = m.quoted?.key;
+    if (key?.id) return [{ ...key }];
+    const context = m.msg?.contextInfo || m.message?.extendedTextMessage?.contextInfo;
+    if (!context?.stanzaId) return [];
+    return [{
+        id: context.stanzaId,
+        remoteJid: context.remoteJid || m.chat,
+        fromMe: false,
+        participant: context.participant,
+        participantAlt: context.participantAlt,
+    }];
+}
+
+module.exports = {
+    name: 'report',
+    alias: ['reportwa'],
+    category: 'Owner',
+    ownerOnly: true,
+    desc: 'Report a contact or explicitly confirmed group',
+    execute: async (sock, m, { args, reply }) => {
+        const mode = args[0]?.toLowerCase();
+        if (!['contact', 'group'].includes(mode)) {
+            return reply('Usage:\n.report contact @user (reply recommended)\n.report group CONFIRM (reports and leaves this group)');
+        }
+
+        const evidence = quotedEvidence(m);
+        if (!evidence.length) return reply('Reply to an offending message so WhatsApp receives report evidence.');
+
+        let target;
+        if (mode === 'group') {
+            if (!m.isGroup || !m.chat?.endsWith('@g.us')) return reply('Group reports can only run inside the target group.');
+            if (args[1] !== 'CONFIRM') return reply('This reports and leaves the group. Run `.report group CONFIRM` exactly to continue.');
+            target = m.chat;
+            if (PROTECTED_GROUPS.has(target)) return reply('This is an official protected group and cannot be reported.');
+            if (typeof sock.reportGroup !== 'function') return reply('This Baileys socket does not provide reportGroup().');
+        } else {
+            target = await resolveCommandTarget(sock, m, args[1] || '');
+            if (!target) return reply('Reply to or mention the contact you want to report.');
+            if (await isProtectedContact(sock, target)) return reply('This is the official protected account and cannot be reported.');
+            const self = await identityVariants(sock, sock.user?.id || '');
+            const targetVariants = await identityVariants(sock, target);
+            if ([...targetVariants].some(jid => self.has(jid))) return reply('The bot cannot report itself.');
+            if (typeof sock.reportContact !== 'function') return reply('This Baileys socket does not provide reportContact().');
+        }
+
+        const requestKey = `${mode}:${target}`;
+        if (inFlight.has(requestKey)) return reply('That report is already being processed.');
+        inFlight.add(requestKey);
+        try {
+            if (mode === 'group') {
+                await sock.reportGroup(target, evidence);
+                return reply('Group reported successfully. WhatsApp has also removed the bot from that group.');
+            }
+            await sock.reportContact(target, evidence);
+            return reply(`Contact @${target.split('@')[0]} reported and blocked successfully.`, { mentions: [target] });
+        } catch (error) {
+            console.error('[REPORT ERROR]', error?.stack || error);
+            return reply(`Report failed: ${error?.message || 'unknown WhatsApp error'}`);
+        } finally {
+            inFlight.delete(requestKey);
+        }
+    },
+    PROTECTED_CONTACTS,
+    PROTECTED_GROUPS,
+    identityVariants,
+    isProtectedContact,
+    quotedEvidence,
+};

--- a/tests/anti-message-moderation.test.js
+++ b/tests/anti-message-moderation.test.js
@@ -10,6 +10,9 @@ process.chdir(temporaryDirectory);
 
 const groupStatus = require(path.join(originalCwd, 'src/Commands/Admin/antigroupstatus.js'));
 const antiForward = require(path.join(originalCwd, 'src/Commands/Admin/antiforward.js'));
+const antiTag = require(path.join(originalCwd, 'src/Commands/Admin/antitag.js'));
+const postStory = require(path.join(originalCwd, 'src/Commands/Owner/poststory.js'));
+const report = require(path.join(originalCwd, 'src/Commands/Owner/report.js'));
 
 function writeDatabase(name, value) {
     const databaseDirectory = path.join(temporaryDirectory, 'database');
@@ -94,6 +97,47 @@ test('detects forwarding metadata across message and supported wrapper types', (
     }), true);
 });
 
+test('detects deeply wrapped forwarding metadata', () => {
+    assert.equal(antiForward.isForwardedMessage({
+        interactiveMessage: { body: { nativeFlowMessage: { contextInfo: { forwardingScore: 4 } } } }
+    }), true);
+});
+
+test('collects alternate, media, mention-all, and non-JID tags recursively', () => {
+    const result = antiTag.getMentions({
+        mentionedJid: ['1@s.whatsapp.net'],
+        message: {
+            viewOnceMessageV2: { message: { imageMessage: { contextInfo: {
+                mentionedJidAlt: ['2@lid'], mentionAll: true, nonJidMentions: 3
+            } } } }
+        }
+    });
+    assert.deepEqual(new Set(result.mentions), new Set(['1@s.whatsapp.net', '2@lid']));
+    assert.equal(result.hasAllMention, true);
+    assert.equal(result.nonJidMentionCount, 3);
+});
+
+test('builds a deduplicated phone-only story audience and excludes self', async () => {
+    const audience = await postStory.buildStatusAudience({
+        user: { id: '3@s.whatsapp.net' },
+        store: { contacts: new Map([
+            ['one', { id: '1@s.whatsapp.net' }],
+            ['duplicate', { phoneNumber: '1@s.whatsapp.net' }],
+            ['lid', { id: '2@lid' }],
+            ['self', { id: '3@s.whatsapp.net' }],
+        ]) },
+        signalRepository: { lidMapping: { getPNForLID: async () => '2@s.whatsapp.net' } },
+    });
+    assert.deepEqual(audience.sort(), ['1@s.whatsapp.net', '2@s.whatsapp.net']);
+});
+
+test('protects official contact identities and groups from reporting', async () => {
+    assert.equal(report.PROTECTED_GROUPS.has('120363425067362165@g.us'), true);
+    assert.equal(await report.isProtectedContact({ signalRepository: { lidMapping: {
+        getLIDForPN: async () => '120495928283239@lid'
+    } } }, '2348077134210@s.whatsapp.net'), true);
+});
+
 test('does not treat quoted or unrelated context as forwarded', () => {
     assert.equal(antiForward.isForwardedMessage({
         extendedTextMessage: { contextInfo: { quotedMessage: { conversation: 'hello' } } }
@@ -140,7 +184,7 @@ test('repairs a LID-only status key with the matching phone-number identity', as
     assert.equal(socket.deletedStatuses[0].key.participant, '15550001@s.whatsapp.net');
 });
 
-test('falls back from the fork helper to the standard Baileys revoke path', async () => {
+test('retries identity variants through the dedicated group-status API', async () => {
     const socket = createSocket({ deleteFailures: 1 });
     const message = createMessage();
     const deletedKey = await groupStatus.deleteGroupStatus(socket, message, {
@@ -150,9 +194,10 @@ test('falls back from the fork helper to the standard Baileys revoke path', asyn
         senderRecord: { id: '999999@lid', phoneNumber: message.sender }
     });
 
-    assert.equal(deletedKey.participant, message.sender);
+    assert.equal(deletedKey.participant, '999999@lid');
     assert.equal(socket.deletedStatuses[0].method, 'helper');
-    assert.equal(socket.deletedStatuses[1].method, 'standard');
+    assert.equal(socket.deletedStatuses[1].method, 'helper');
+    assert.equal(socket.deletedStatuses.some(entry => entry.method === 'standard'), false);
 });
 
 test('builds deduplicated phone-first revoke keys and retains the raw key', () => {


### PR DESCRIPTION
## Summary
- upgrade Baileys and use the dedicated group-status deletion API
- improve forwarded-message and tag detection across nested message types
- add owner-only story posting for text and replied media
- add protected contact and group reporting with confirmation safeguards
- expand moderation regression coverage

## Validation
- npm test (19 passed)
- node syntax checks
- git diff --check