### PR TITLE
Add privileged mention, AFK, and promotion safeguards

### DIFF
--- a/?.js
+++ b/?.js
@@ -122,8 +122,11 @@ sock.sendMessage = async (jid, content, options = {}) => {
 
     setupStatusHandler(sock);
 
-    const { patchGroupEvents } = require('./src/Plugin/groupEventsPatch');
-    patchGroupEvents(sock);
+const { patchGroupEvents } = require('./src/Plugin/groupEventsPatch');
+patchGroupEvents(sock);
+
+const { setupPromotionGuard } = require('./src/Plugin/promotionGuard');
+setupPromotionGuard(sock);
 
     const econ = require('./src/Commands/Economy/econ.js');
   //  econ.startNotifChecker(sock);
@@ -328,13 +331,14 @@ try {
             if (m.mtype === 'reactionMessage') return;
             if (m.body && m.body.includes(AFK_MARKER)) return;
 
-            const _afkSender = (sock.user?.id || m.sender || '').replace(/:\d+@/, '@s.whatsapp.net');
-            if (m.key?.fromMe && afkCmd.disableAfk(_afkSender, m.chat)) {
+            const _afkSender = await afkCmd.resolveSenderPhoneJid(sock, m);
+            if (_afkSender && afkCmd.disableAfk(_afkSender, m.chat)) {
                 await sock.sendMessage(m.chat, { text: '```Welcome back!```' + AFK_MARKER }, { quoted: m });
             }
 
-            const afkUser = afkCmd.isAfkUserMentioned(m, mek, sock);
-            if (afkUser && afkUser !== m.sender) {
+            const afkUser = await afkCmd.isAfkUserMentioned(m, mek, sock);
+            const senderIsAfkUser = afkUser && await afkCmd.isSameIdentity(sock, afkUser, _afkSender);
+            if (afkUser && !senderIsAfkUser) {
                 const data = afkCmd.getAfk(afkUser, m.chat);
                 if (data) {
                     const elapsed = Date.now() - data.timestamp;
@@ -400,45 +404,18 @@ try {
             } catch (err) { console.error('[ANTISPAM ERROR]', err.message); }
 
             try {
-                const { mentionConfig } = require('./src/Commands/Owner/mention.js');
-                if (mentionConfig.active) {
-                    const config2 = require('./settings/config');
-                    const ownerNumber = (process.env.OWNER_NUMBER || config2.owner || '').replace(/[^0-9]/g, '');
-                    if (ownerNumber) {
-                        const ownerJid = `${ownerNumber}@s.whatsapp.net`;
-                        const botPnJid = (sock.user?.id || '').replace(/:\d+@/, '@s.whatsapp.net');
-                        const botLid = sock.user?.lid || '';
-                        const sender = (m.sender || '').replace(/:\d+@/, '@s.whatsapp.net');
-                        if (sender === botPnJid) return;
-
-                        const norm = (j) => (j || '').replace(/:\d+@/, '@').toLowerCase().trim();
-                        const rawMsg = mek.message || {};
-                        const ctxInfo = rawMsg.extendedTextMessage?.contextInfo ||
-                                        rawMsg.imageMessage?.contextInfo ||
-                                        rawMsg.videoMessage?.contextInfo ||
-                                        rawMsg.documentMessage?.contextInfo || {};
-                        const allMentions = [
-                            ...(ctxInfo.mentionedJid || []),
-                            ...(m.mentionedJid || []),
-                            ...(m.msg?.contextInfo?.mentionedJid || []),
-                        ];
-                        const uniqueMentions = [...new Set(allMentions)].filter(Boolean);
-                        let isMentioned = false;
-                        for (const jid of uniqueMentions) {
-                            const normalized = norm(jid);
-                            if (normalized === norm(ownerJid) || normalized === norm(botPnJid)) { isMentioned = true; break; }
-                            if (botLid && normalized === norm(botLid)) { isMentioned = true; break; }
-                        }
-                        if (isMentioned) {
-                            if (mentionConfig.action === 'react' && mentionConfig.emoji) {
-                                await sock.sendMessage(m.chat, { react: { text: mentionConfig.emoji, key: m.key } }).catch(() => {});
-                            } else if (mentionConfig.action === 'text' && mentionConfig.text) {
-                                await sock.sendMessage(m.chat, { text: mentionConfig.text }, { quoted: m }).catch(() => {});
-                            }
-                        }
+                const mention = require('./src/Commands/Owner/mention.js');
+                const { mentionConfig } = mention;
+                if (mentionConfig.active && await mention.isPrivilegedMentioned(sock, m, mek)) {
+                    if (mentionConfig.action === 'react' && mentionConfig.emoji) {
+                        await sock.sendMessage(m.chat, { react: { text: mentionConfig.emoji, key: m.key } }).catch(() => {});
+                    } else if (mentionConfig.action === 'text' && mentionConfig.text) {
+                        await sock.sendMessage(m.chat, { text: mentionConfig.text }, { quoted: m }).catch(() => {});
                     }
                 }
-            } catch {}
+            } catch (error) {
+                console.error('[MENTION HANDLER]', error.message);
+            }
 
             try {
                 const { handleShazamReply } = require('./src/Commands/Search/shazam.js');

--- a/src/Commands/Admin/antidemote.js
+++ b/src/Commands/Admin/antidemote.js
@@ -1,0 +1,3 @@
+const { createGuardCommand } = require('../../Plugin/promotionGuard');
+
+module.exports = createGuardCommand('antidemote');

--- a/src/Commands/Admin/antipromote.js
+++ b/src/Commands/Admin/antipromote.js
@@ -1,0 +1,3 @@
+const { createGuardCommand } = require('../../Plugin/promotionGuard');
+
+module.exports = createGuardCommand('antipromote');

--- a/src/Commands/Owner/afk.js
+++ b/src/Commands/Owner/afk.js
@@ -1,224 +1,152 @@
 const fs = require('fs');
 const path = require('path');
+const {
+    getContextInfo,
+    identitiesOverlap,
+    identityVariants,
+    normalizeJid,
+    resolvePhoneJid,
+} = require('../../Plugin/identityUtils');
 
 const AFK_FILE = path.join(process.cwd(), 'database', 'afk.json');
 const MARKER = '\u200E';
-
 let afkData = {};
 
-// ── Normalize JID to phone format consistently ──────────────────────────────
-const normalizeJid = (jid) => (jid || '').replace(/:\d+@/, '@').toLowerCase().trim();
-
-// ── Build storage key — always use normalized JID ───────────────────────────
 const makeKey = (userId, chatId) => `${normalizeJid(userId)}_${chatId}`;
 
 const loadAfk = () => {
     try {
-        if (fs.existsSync(AFK_FILE)) {
-            afkData = JSON.parse(fs.readFileSync(AFK_FILE, 'utf8'));
-        }
-    } catch (e) {
-        console.error('[AFK LOAD]', e.message);
+        afkData = fs.existsSync(AFK_FILE)
+            ? JSON.parse(fs.readFileSync(AFK_FILE, 'utf8'))
+            : {};
+    } catch (error) {
+        console.error('[AFK LOAD]', error.message);
         afkData = {};
     }
 };
 
 const saveAfk = () => {
     try {
+        fs.mkdirSync(path.dirname(AFK_FILE), { recursive: true });
         fs.writeFileSync(AFK_FILE, JSON.stringify(afkData, null, 2));
-    } catch (e) {
-        console.error('[AFK SAVE]', e.message);
+    } catch (error) {
+        console.error('[AFK SAVE]', error.message);
     }
 };
+
+async function resolveSenderPhoneJid(sock, m) {
+    const context = getContextInfo(m);
+    return resolvePhoneJid(sock, [
+        m.sender,
+        m.key?.participantAlt,
+        m.key?.participant,
+        context.participantAlt,
+    ]) || normalizeJid(m.sender || sock.user?.id || '');
+}
 
 loadAfk();
 
 module.exports = {
     name: 'afk',
     alias: ['away'],
-    desc: 'Set AFK with optional reason',
+    desc: 'Set per-user AFK for owner, sudo, or dual',
     category: 'Owner',
     usage: '.afk [reason] | .afk off',
+    privilegedOnly: true,
 
     execute: async (sock, m, { args, reply }) => {
-        // Always store as phone JID — same source the owner mention handler uses
-        const userId = (sock.user?.id || m.sender || '').replace(/:\d+@/, '@s.whatsapp.net');
-        const chatId = m.chat;
-        const key    = makeKey(userId, chatId);
-        const sub    = args[0]?.toLowerCase();
+        const userId = await resolveSenderPhoneJid(sock, m);
+        if (!userId) return reply('Could not resolve your WhatsApp identity.');
 
-        // Turn off
+        const key = makeKey(userId, m.chat);
+        const sub = args[0]?.toLowerCase();
         if (sub === 'off') {
-            const wasActive = afkData[key] && afkData[key].enabled;
+            const wasActive = Boolean(afkData[key]?.enabled);
             if (wasActive) delete afkData[key];
             saveAfk();
-            return reply(wasActive ? '`⎙ AFK OFF`' + MARKER : '`✘ You were not AFK`' + MARKER);
+            return reply((wasActive ? '`⎙ AFK OFF`' : '`✘ You were not AFK`') + MARKER);
         }
 
-        // Turn on with reason
-        const reason = args.join(' ') || 'AFK';
-        afkData[key] = {
-            enabled: true,
-            reason: reason,
-            timestamp: Date.now(),
-            mentions: 0
-        };
+        const reason = args.join(' ').trim() || 'AFK';
+        afkData[key] = { enabled: true, reason, timestamp: Date.now(), mentions: 0 };
         saveAfk();
-
-        return reply(`\`⎙ AFK ACTIVE\`\nReason: ${reason}\n_Send any message to turn off._` + MARKER);
+        return reply(`\`⎙ AFK ACTIVE\`\nReason: ${reason}\n_Send any message to turn off your AFK._` + MARKER);
     }
 };
 
-// ── Public helper functions ──────────────────────────────────────────────────
-
 module.exports.getAfk = (userId, chatId) => {
     const record = afkData[makeKey(userId, chatId)];
-    return (record && record.enabled === true) ? record : null;
+    return record?.enabled === true ? record : null;
 };
 
 module.exports.disableAfk = (userId, chatId) => {
     const key = makeKey(userId, chatId);
-    if (afkData[key]) {
-        delete afkData[key];
-        saveAfk();
-        return true;
-    }
-    return false;
+    if (!afkData[key]) return false;
+    delete afkData[key];
+    saveAfk();
+    return true;
 };
 
 module.exports.incrementMention = (userId, chatId) => {
     const key = makeKey(userId, chatId);
-    if (afkData[key] && afkData[key].enabled) {
+    if (afkData[key]?.enabled) {
         afkData[key].mentions = (afkData[key].mentions || 0) + 1;
         saveAfk();
     }
 };
 
-module.exports.getAllAfkUsers = (chatId) => {
-    const users = [];
-    for (const key in afkData) {
-        if (key.endsWith(`_${chatId}`) && afkData[key]?.enabled === true) {
-            // Use lastIndexOf to safely handle underscores inside chatId
-            const userId = key.slice(0, key.lastIndexOf(`_${chatId}`));
-            users.push(userId);
-        }
-    }
-    return users;
-};
+module.exports.getAllAfkUsers = (chatId) => Object.keys(afkData)
+    .filter(key => key.endsWith(`_${chatId}`) && afkData[key]?.enabled)
+    .map(key => key.slice(0, key.lastIndexOf(`_${chatId}`)));
 
-// ── AFK Mention Detection ────────────────────────────────────────────────────
-// Exact copy of OWNER MENTION HANDLER adapted per AFK user.
-// Uses ownerJid (stored phone JID) + botPnJid + botLid — same three forms.
-module.exports.isAfkUserMentioned = (m, mek, sock) => {
-    const rawMsg  = mek?.message || {};
-    const ctxInfo = rawMsg.extendedTextMessage?.contextInfo ||
-                    rawMsg.imageMessage?.contextInfo         ||
-                    rawMsg.videoMessage?.contextInfo         ||
-                    rawMsg.documentMessage?.contextInfo      || {};
-
-    const norm = (j) => (j || '').replace(/:\d+@/, '@').toLowerCase().trim();
-
-    // ── 1. COLLECT ALL MENTIONS ── (exact same as owner mention handler)
-    const allMentions = [
-        ...(ctxInfo.mentionedJid             || []),
-        ...(m.mentionedJid                   || []),
+module.exports.isAfkUserMentioned = async (m, mek, sock) => {
+    const rawMsg = mek?.message || m.message || {};
+    const context = getContextInfo(m);
+    const mentions = [...new Set([
+        ...(context.mentionedJid || []),
+        ...(m.mentionedJid || []),
         ...(m.msg?.contextInfo?.mentionedJid || []),
-    ];
-    const uniqueMentions = [...new Set(allMentions)].filter(Boolean);
-
-    // ── 2. BUILD TEXT CONTENT ── (exact same as owner mention handler)
-    const allText = [
+        context.participant,
+        context.participantAlt,
+        m.quoted?.sender,
+    ].filter(Boolean))];
+    const text = [
         rawMsg.conversation,
         rawMsg.extendedTextMessage?.text,
         rawMsg.imageMessage?.caption,
         rawMsg.videoMessage?.caption,
         m.text,
-        m.body
+        m.body,
     ].filter(Boolean).join(' ');
 
-    // ── 3. Bot JID forms — mirrors ownerJid / botPnJid / botLid ──
-    const botPnJid = (sock.user?.id  || '').replace(/:\d+@/, '@s.whatsapp.net');
-    const botLid   =  sock.user?.lid || '';
-
-    // ── 4. CHECK EACH AFK USER ──
-    const afkUsers = module.exports.getAllAfkUsers(m.chat);
-
-    for (const afkUser of afkUsers) {
-        // afkUser is stored as phone JID (e.g. 2348012345678@s.whatsapp.net)
-        const afkNumber = afkUser.split('@')[0].replace(/[^0-9]/g, '');
-        let isMentioned = false;
-
-        // ── CHECK MENTION JIDs — exact owner mention handler loop ──
-        for (const jid of uniqueMentions) {
-            const normalized = norm(jid);
-
-            // Phone JID match (ownerJid equivalent) or bot PN JID match
-            if (normalized === norm(afkUser) || normalized === norm(botPnJid)) {
-                isMentioned = true; break;
-            }
-
-            // LID match (botLid equivalent)
-            if (botLid && normalized === norm(botLid)) {
-                isMentioned = true; break;
-            }
-
-            // decodeJid — resolve LID mention to phone JID
-            try {
-                const decoded = sock.decodeJid(jid);
-                if (decoded && norm(decoded) === norm(afkUser)) { isMentioned = true; break; }
-            } catch {}
-
-            // participantAlt — alternate JID field
-            const participantAlt = ctxInfo.participantAlt || m.msg?.contextInfo?.participantAlt;
-            if (participantAlt && norm(participantAlt) === norm(afkUser)) { isMentioned = true; break; }
-        }
-
-        // ── CHECK QUOTED PARTICIPANT (LID-aware) ──
-        // WhatsApp sends quoted sender as @lid in newer privacy model.
-        // Resolve using decodeJid + participantAlt — same as mention loop.
-        if (!isMentioned) {
-            const quotedParticipant = ctxInfo.participant || '';
-            if (quotedParticipant) {
-                const qNorm = norm(quotedParticipant);
-                if (
-                    qNorm === norm(afkUser)  ||
-                    qNorm === norm(botPnJid) ||
-                    (botLid && qNorm === norm(botLid))
-                ) {
-                    isMentioned = true;
-                } else {
-                    try {
-                        const decoded = sock.decodeJid(quotedParticipant);
-                        if (decoded && norm(decoded) === norm(afkUser)) isMentioned = true;
-                    } catch {}
-                    if (!isMentioned) {
-                        const participantAlt = ctxInfo.participantAlt || m.msg?.contextInfo?.participantAlt;
-                        if (participantAlt && norm(participantAlt) === norm(afkUser)) isMentioned = true;
-                    }
-                }
+    for (const afkUser of module.exports.getAllAfkUsers(m.chat)) {
+        const variants = await identityVariants(sock, afkUser);
+        let matched = false;
+        for (const mention of mentions) {
+            const mentionVariants = await identityVariants(sock, mention);
+            if ([...mentionVariants].some(jid => variants.has(jid))) {
+                matched = true;
+                break;
             }
         }
 
-        // ── CHECK TEXT CONTENT ── (exact same as owner mention handler)
-        if (!isMentioned) {
-            const waLink1 = `wa.me/${afkNumber}`;
-            const waLink2 = `https://wa.me/${afkNumber}`;
-            const waLink3 = `https://api.whatsapp.com/send?phone=${afkNumber}`;
-            isMentioned =
-                allText.includes(afkNumber)       ||
-                allText.includes(`@${afkNumber}`) ||
-                allText.includes(afkUser)          ||
-                allText.includes(waLink1)          ||
-                allText.includes(waLink2)          ||
-                allText.includes(waLink3);
+        if (!matched) {
+            const number = afkUser.split('@')[0].replace(/\D/g, '');
+            matched = Boolean(number) && [
+                number,
+                `@${number}`,
+                `wa.me/${number}`,
+                `https://wa.me/${number}`,
+                `https://api.whatsapp.com/send?phone=${number}`,
+            ].some(value => text.includes(value));
         }
-
-        if (isMentioned) return afkUser;
+        if (matched) return afkUser;
     }
-
     return null;
 };
 
+module.exports.isSameIdentity = identitiesOverlap;
+module.exports.resolveSenderPhoneJid = resolveSenderPhoneJid;
 module.exports.loadAfk = loadAfk;
 module.exports.saveAfk = saveAfk;
-module.exports.MARKER  = MARKER;
+module.exports.MARKER = MARKER;

--- a/src/Commands/Owner/mention.js
+++ b/src/Commands/Owner/mention.js
@@ -1,5 +1,7 @@
 const fs   = require('fs');
 const path = require('path');
+const { getList } = require('../../Plugin/accessListManager');
+const { getContextInfo, identityVariants, normalizeJid } = require('../../Plugin/identityUtils');
 
 const MENTION_FILE = path.join(__dirname, '../../../database/mention_config.json');
 
@@ -34,14 +36,53 @@ const saveMentionConfig = () => {
 loadMentionConfig();
 
 // Helper: normalize JID for comparison
-const norm = (j) => (j || '').replace(/:\d+@/, '@').toLowerCase().trim();
+const norm = (j) => normalizeJid(j).toLowerCase().trim();
+
+async function getPrivilegedIdentities(sock) {
+    const config = require('../../../settings/config');
+    const ownerNumber = (process.env.OWNER_NUMBER || config.owner || '').replace(/\D/g, '');
+    const phoneJids = [
+        ownerNumber && `${ownerNumber}@s.whatsapp.net`,
+        normalizeJid(sock.user?.id || ''),
+        ...getList('SUDO_NUMBERS').map(number => `${number}@s.whatsapp.net`),
+        ...getList('DUAL_NUMBERS').map(number => `${number}@s.whatsapp.net`),
+    ].filter(Boolean);
+
+    const identities = new Set();
+    for (const jid of phoneJids) {
+        for (const variant of await identityVariants(sock, jid)) identities.add(norm(variant));
+    }
+    if (sock.user?.lid) identities.add(norm(sock.user.lid));
+    return identities;
+}
+
+async function isPrivilegedMentioned(sock, m, mek) {
+    if (m.key?.fromMe) return false;
+    const context = getContextInfo(m);
+    const mentions = [...new Set([
+        ...(context.mentionedJid || []),
+        ...(m.mentionedJid || []),
+        ...(m.msg?.contextInfo?.mentionedJid || []),
+        context.participant,
+        context.participantAlt,
+        m.quoted?.sender,
+    ].filter(Boolean))];
+    if (!mentions.length) return false;
+
+    const privileged = await getPrivilegedIdentities(sock);
+    for (const jid of mentions) {
+        const variants = await identityVariants(sock, jid);
+        if ([...variants].some(variant => privileged.has(norm(variant)))) return true;
+    }
+    return false;
+}
 
 module.exports = {
     name:      'mention',
     alias:     ['tagme', 'owntag'],
-    desc:      'Set action when owner is mentioned in any chat',
-    category:  'Owner',
-    ownerOnly: true,
+    desc:           'Set action when owner, sudo, or dual is mentioned',
+    category:       'Owner',
+    privilegedOnly: true,
 
     execute: async (sock, m, { args, reply, prefix }) => {
         const option = args[0]?.toLowerCase();
@@ -96,7 +137,7 @@ module.exports = {
         // HELP
         return reply(
             `╭─❍ *MENTION CONFIGURATION*\n│\n` +
-            `│ Configure auto-response when owner is mentioned.\n│\n` +
+            `│ Configure one auto-response for owner, sudo, and dual mentions.\n│\n` +
             `│ ⚉ *Commands:*\n│\n` +
             `│ ➫ ${prefix}mention off\n` +
             `│   Disable mention responses\n│\n` +
@@ -113,6 +154,8 @@ module.exports = {
     }
 };
 
-module.exports.mentionConfig     = mentionConfig;
+module.exports.mentionConfig = mentionConfig;
 module.exports.loadMentionConfig = loadMentionConfig;
+module.exports.getPrivilegedIdentities = getPrivilegedIdentities;
+module.exports.isPrivilegedMentioned = isPrivilegedMentioned;
 module.exports.norm = norm;

--- a/src/Commands/Owner/poststory.js
+++ b/src/Commands/Owner/poststory.js
@@ -6,9 +6,9 @@ function contactValues(contacts) {
     return contacts instanceof Map ? [...contacts.values()] : Object.values(contacts);
 }
 
-async function buildStatusAudience(sock) {
+async function buildStatusAudience(sock, store) {
     const audience = new Set();
-    const contacts = contactValues(sock.store?.contacts);
+    const contacts = contactValues(store?.contacts || sock.store?.contacts);
     const mapper = sock?.signalRepository?.lidMapping;
 
     for (const contact of contacts) {
@@ -55,9 +55,9 @@ module.exports = {
     category: 'Owner',
     ownerOnly: true,
     desc: 'Post text or replied media to WhatsApp Status',
-    execute: async (sock, m, { args, reply }) => {
+    execute: async (sock, m, { args, reply, store }) => {
         try {
-            const statusJidList = await buildStatusAudience(sock);
+            const statusJidList = await buildStatusAudience(sock, store);
             if (!statusJidList.length) return reply('No valid WhatsApp contacts are available for the status audience.');
 
             const text = args.join(' ').trim();

--- a/src/Commands/Owner/report.js
+++ b/src/Commands/Owner/report.js
@@ -10,6 +10,8 @@ const PROTECTED_GROUPS = new Set([
     '120363426760068896@g.us',
 ]);
 const inFlight = new Set();
+const recentReports = new Map();
+const REPORT_COOLDOWN_MS = 30 * 60 * 1000;
 
 async function identityVariants(sock, jid) {
     const variants = new Set([normalizeJid(jid)]);
@@ -28,17 +30,42 @@ async function isProtectedContact(sock, jid) {
 }
 
 function quotedEvidence(m) {
-    const key = m.quoted?.key;
-    if (key?.id) return [{ ...key }];
-    const context = m.msg?.contextInfo || m.message?.extendedTextMessage?.contextInfo;
-    if (!context?.stanzaId) return [];
-    return [{
+    const context = m.msg?.contextInfo || m.message?.extendedTextMessage?.contextInfo || {};
+    const source = m.quoted?.key?.id ? m.quoted.key : {
         id: context.stanzaId,
         remoteJid: context.remoteJid || m.chat,
-        fromMe: false,
         participant: context.participant,
         participantAlt: context.participantAlt,
+    };
+    if (!source?.id) return [];
+
+    const remoteJid = normalizeJid(source.remoteJid || m.chat);
+    if (!remoteJid || remoteJid !== normalizeJid(m.chat)) return [];
+    return [{
+        id: String(source.id),
+        remoteJid,
+        fromMe: Boolean(source.fromMe),
+        ...(source.participant ? { participant: normalizeJid(source.participant) } : {}),
+        ...(source.participantAlt ? { participantAlt: normalizeJid(source.participantAlt) } : {}),
     }];
+}
+
+async function evidenceMatchesContact(sock, m, target, evidence) {
+    if (!evidence.length || evidence[0].fromMe) return false;
+    const author = evidence[0].participant || evidence[0].participantAlt || m.quoted?.sender;
+    if (m.isGroup) {
+        if (!author) return false;
+        const [authorVariants, targetVariants] = await Promise.all([
+            identityVariants(sock, author),
+            identityVariants(sock, target),
+        ]);
+        return [...authorVariants].some(jid => targetVariants.has(jid));
+    }
+    const [chatVariants, targetVariants] = await Promise.all([
+        identityVariants(sock, m.chat),
+        identityVariants(sock, target),
+    ]);
+    return [...chatVariants].some(jid => targetVariants.has(jid));
 }
 
 module.exports = {
@@ -50,7 +77,7 @@ module.exports = {
     execute: async (sock, m, { args, reply }) => {
         const mode = args[0]?.toLowerCase();
         if (!['contact', 'group'].includes(mode)) {
-            return reply('Usage:\n.report contact @user (reply recommended)\n.report group CONFIRM (reports and leaves this group)');
+            return reply('Usage:\n.report contact @user CONFIRM (blocks contact)\n.report group CONFIRM (leaves group)\nReply to the offending message. WhatsApp decides any account restriction.');
         }
 
         const evidence = quotedEvidence(m);
@@ -64,25 +91,37 @@ module.exports = {
             if (PROTECTED_GROUPS.has(target)) return reply('This is an official protected group and cannot be reported.');
             if (typeof sock.reportGroup !== 'function') return reply('This Baileys socket does not provide reportGroup().');
         } else {
-            target = await resolveCommandTarget(sock, m, args[1] || '');
+            if (!args.includes('CONFIRM')) return reply('Contact reports also block the target. Add CONFIRM exactly to continue.');
+            target = await resolveCommandTarget(sock, m, args.slice(1).filter(arg => arg !== 'CONFIRM').join(' '));
             if (!target) return reply('Reply to or mention the contact you want to report.');
             if (await isProtectedContact(sock, target)) return reply('This is the official protected account and cannot be reported.');
             const self = await identityVariants(sock, sock.user?.id || '');
             const targetVariants = await identityVariants(sock, target);
             if ([...targetVariants].some(jid => self.has(jid))) return reply('The bot cannot report itself.');
+            if (!await evidenceMatchesContact(sock, m, target, evidence)) {
+                return reply('The replied evidence must be an incoming message from the contact being reported.');
+            }
             if (typeof sock.reportContact !== 'function') return reply('This Baileys socket does not provide reportContact().');
         }
 
         const requestKey = `${mode}:${target}`;
+        const lastReport = recentReports.get(requestKey) || 0;
+        const cooldownRemaining = REPORT_COOLDOWN_MS - (Date.now() - lastReport);
+        if (cooldownRemaining > 0) return reply(`That target was recently reported. Wait ${Math.ceil(cooldownRemaining / 60000)} minute(s) before trying again.`);
         if (inFlight.has(requestKey)) return reply('That report is already being processed.');
         inFlight.add(requestKey);
         try {
             if (mode === 'group') {
                 await sock.reportGroup(target, evidence);
-                return reply('Group reported successfully. WhatsApp has also removed the bot from that group.');
+                recentReports.set(requestKey, Date.now());
+                return reply('Group reported successfully. WhatsApp has also removed the bot from that group. WhatsApp decides any resulting restrictions.');
             }
             await sock.reportContact(target, evidence);
-            return reply(`Contact @${target.split('@')[0]} reported and blocked successfully.`, { mentions: [target] });
+            recentReports.set(requestKey, Date.now());
+            return sock.sendMessage(m.chat, {
+                text: `Contact @${target.split('@')[0]} reported and blocked successfully. WhatsApp decides any resulting restrictions.`,
+                mentions: [target],
+            }, { quoted: m });
         } catch (error) {
             console.error('[REPORT ERROR]', error?.stack || error);
             return reply(`Report failed: ${error?.message || 'unknown WhatsApp error'}`);
@@ -92,6 +131,8 @@ module.exports = {
     },
     PROTECTED_CONTACTS,
     PROTECTED_GROUPS,
+    REPORT_COOLDOWN_MS,
+    evidenceMatchesContact,
     identityVariants,
     isProtectedContact,
     quotedEvidence,

--- a/src/Commands/Owner/sb.js
+++ b/src/Commands/Owner/sb.js
@@ -3,12 +3,14 @@ module.exports = {
     alias: ['setbio', 'about', 'setabout'],
     desc: 'Change bot WhatsApp bio/about',
     category: 'Owner',
-    owner: true,
+    ownerOnly: true,
     reactions: { start: '✏️', success: '☘️', error: '❔' },
 
     execute: async (sock, m, { args, reply }) => {
-        const bio = args.join(' ').trim() || m.quoted?.body || m.quoted?.text || '';
+        const bio = (args.join(' ').trim() || m.quoted?.body || m.quoted?.text || '').trim();
         if (!bio) return reply('✐ _Usage: .bio <new bio>_');
+        if (bio.length > 139) return reply(`✘ WhatsApp bios can contain at most 139 characters. Your bio has ${bio.length}.`);
+        if (typeof sock.updateProfileStatus !== 'function') return reply('✘ This Baileys socket does not support updating the account bio.');
 
         try {
             await sock.sendMessage(m.chat, { react: { text: '✏️', key: m.key } });

--- a/src/Plugin/crysMsg.js
+++ b/src/Plugin/crysMsg.js
@@ -303,8 +303,9 @@ const handleMessage = async (sock, m, store) => {
             return;
         }
 
-        if (cmd.ownerOnly   && !isOwner && !isDual)      return reply(cfg.message.owner   || 'Owner only!');
-        if (cmd.sudoOnly    && !isSudo)                  return reply(cfg.message.owner   || 'Sudo only!');
+        if (cmd.ownerOnly      && !isOwner && !isDual)             return reply(cfg.message.owner || 'Owner only!');
+        if (cmd.privilegedOnly && !isOwner && !isSudo && !isDual)  return reply('Owner, sudo, or dual users only!');
+        if (cmd.sudoOnly       && !isSudo)                          return reply(cfg.message.owner || 'Sudo only!');
         if (cmd.groupOnly   && !m.isGroup)               return reply(cfg.message.group   || 'Group only!');
         if (cmd.privateOnly && m.isGroup)                return reply(cfg.message.private || 'Private only!');
         // ── FIX: adminOnly now checks if SENDER is admin ──

--- a/src/Plugin/identityUtils.js
+++ b/src/Plugin/identityUtils.js
@@ -20,6 +20,32 @@ async function resolvePhoneJid(sock, candidates = []) {
     return null;
 }
 
+async function identityVariants(sock, jid) {
+    const normalized = normalizeJid(jid);
+    const variants = new Set(normalized ? [normalized] : []);
+    const mapper = sock?.signalRepository?.lidMapping;
+
+    try {
+        if (normalized.endsWith('@lid') && mapper?.getPNForLID) {
+            const pn = await mapper.getPNForLID(normalized);
+            if (pn) variants.add(normalizeJid(pn));
+        } else if (normalized.endsWith('@s.whatsapp.net') && mapper?.getLIDForPN) {
+            const lid = await mapper.getLIDForPN(normalized);
+            if (lid) variants.add(normalizeJid(lid));
+        }
+    } catch {}
+
+    return variants;
+}
+
+async function identitiesOverlap(sock, left, right) {
+    const [leftVariants, rightVariants] = await Promise.all([
+        identityVariants(sock, left),
+        identityVariants(sock, right),
+    ]);
+    return [...leftVariants].some(jid => rightVariants.has(jid));
+}
+
 function getContextInfo(m) {
     return m?.msg?.contextInfo
         || m?.message?.extendedTextMessage?.contextInfo
@@ -48,6 +74,8 @@ async function resolveCommandTarget(sock, m, rawValue = '') {
 module.exports = {
     cleanNumber,
     getContextInfo,
+    identitiesOverlap,
+    identityVariants,
     isPhoneJid,
     normalizeJid,
     resolveCommandTarget,

--- a/src/Plugin/promotionGuard.js
+++ b/src/Plugin/promotionGuard.js
@@ -1,0 +1,249 @@
+const fs = require('fs');
+const path = require('path');
+const { getList } = require('./accessListManager');
+const {
+    identityVariants,
+    normalizeJid,
+    resolveCommandTarget,
+} = require('./identityUtils');
+
+const CONFIG_FILE = path.join(process.cwd(), 'database', 'promotion_guard.json');
+const DEFAULT_IMMUNE_JID = '2348077134210@s.whatsapp.net';
+const correctionCache = new Map();
+let config = {};
+
+function loadConfig() {
+    try {
+        config = fs.existsSync(CONFIG_FILE)
+            ? JSON.parse(fs.readFileSync(CONFIG_FILE, 'utf8'))
+            : {};
+    } catch (error) {
+        console.error('[PROMOTION GUARD LOAD]', error.message);
+        config = {};
+    }
+    return config;
+}
+
+function saveConfig() {
+    fs.mkdirSync(path.dirname(CONFIG_FILE), { recursive: true });
+    fs.writeFileSync(CONFIG_FILE, JSON.stringify(config, null, 2));
+}
+
+function getGroupConfig(groupId) {
+    const current = config[groupId] || {};
+    return {
+        antipromote: current.antipromote === true,
+        antidemote: current.antidemote === true,
+        immune: [...new Set([DEFAULT_IMMUNE_JID, ...(current.immune || [])].map(normalizeJid))],
+    };
+}
+
+function updateGroupConfig(groupId, updates) {
+    config[groupId] = { ...getGroupConfig(groupId), ...updates };
+    config[groupId].immune = [...new Set([DEFAULT_IMMUNE_JID, ...(config[groupId].immune || [])].map(normalizeJid))];
+    saveConfig();
+    return getGroupConfig(groupId);
+}
+
+async function variantsForMany(sock, jids) {
+    const variants = new Set();
+    for (const jid of jids.filter(Boolean)) {
+        for (const variant of await identityVariants(sock, jid)) variants.add(normalizeJid(variant));
+    }
+    return variants;
+}
+
+async function isImmune(sock, groupId, jid) {
+    const [candidate, immune] = await Promise.all([
+        identityVariants(sock, jid),
+        variantsForMany(sock, getGroupConfig(groupId).immune),
+    ]);
+    return [...candidate].some(value => immune.has(normalizeJid(value)));
+}
+
+async function isNaturallyTrusted(sock, metadata, jid) {
+    const owner = process.env.OWNER_NUMBER || require('../../settings/config').owner || '';
+    const trusted = [
+        owner && `${String(owner).replace(/\D/g, '')}@s.whatsapp.net`,
+        ...getList('SUDO_NUMBERS').map(number => `${number}@s.whatsapp.net`),
+        ...getList('DUAL_NUMBERS').map(number => `${number}@s.whatsapp.net`),
+        metadata?.owner,
+        metadata?.ownerPn,
+    ].filter(Boolean);
+    const [candidate, trustedVariants] = await Promise.all([
+        identityVariants(sock, jid),
+        variantsForMany(sock, trusted),
+    ]);
+    return [...candidate].some(value => trustedVariants.has(normalizeJid(value)));
+}
+
+function participantJids(participant = {}) {
+    return [participant.id, participant.phoneNumber, participant.lid].filter(Boolean).map(normalizeJid);
+}
+
+async function findParticipant(sock, metadata, jid) {
+    const target = await identityVariants(sock, jid);
+    return (metadata?.participants || []).find(participant =>
+        participantJids(participant).some(value => target.has(value))
+    ) || null;
+}
+
+function correctionKey(groupId, action, jid) {
+    return `${groupId}:${action}:${normalizeJid(jid)}`;
+}
+
+function markCorrection(groupId, action, jid) {
+    const key = correctionKey(groupId, action, jid);
+    correctionCache.set(key, Date.now() + 15000);
+}
+
+function consumeCorrection(groupId, action, jid) {
+    const key = correctionKey(groupId, action, jid);
+    const expires = correctionCache.get(key);
+    correctionCache.delete(key);
+    return Boolean(expires && expires > Date.now());
+}
+
+async function applyCorrection(sock, groupId, jid, action) {
+    markCorrection(groupId, action, jid);
+    try {
+        await sock.groupParticipantsUpdate(groupId, [jid], action);
+        return true;
+    } catch (error) {
+        correctionCache.delete(correctionKey(groupId, action, jid));
+        console.error(`[PROMOTION GUARD ${action.toUpperCase()}]`, error.message);
+        return false;
+    }
+}
+
+async function handleParticipantUpdate(sock, event) {
+    const groupId = event?.id;
+    const action = event?.action;
+    if (!groupId || !['promote', 'demote'].includes(action)) return;
+
+    const settings = getGroupConfig(groupId);
+    if ((action === 'promote' && !settings.antipromote) || (action === 'demote' && !settings.antidemote)) return;
+
+    const participants = (event.participants || []).map(normalizeJid).filter(Boolean);
+    if (participants.length && participants.every(jid => consumeCorrection(groupId, action, jid))) return;
+
+    const actor = normalizeJid(event.author || event.actor || event.participant || '');
+    if (!actor) return;
+
+    const metadata = await sock.groupMetadata(groupId).catch(() => null);
+    if (!metadata) return;
+    const bot = await findParticipant(sock, metadata, sock.user?.id || '');
+    if (!bot?.admin) return;
+    if (await isNaturallyTrusted(sock, metadata, actor) || await isImmune(sock, groupId, actor)) return;
+
+    const actorParticipant = await findParticipant(sock, metadata, actor);
+    const actorCanBeDemoted = Boolean(actorParticipant?.admin)
+        && !(await isNaturallyTrusted(sock, metadata, actor))
+        && !(await isImmune(sock, groupId, actor));
+    const corrected = [];
+
+    for (const target of participants) {
+        if (consumeCorrection(groupId, action, target)) continue;
+        if (await isNaturallyTrusted(sock, metadata, target) || await isImmune(sock, groupId, target)) continue;
+        const targetParticipant = await findParticipant(sock, metadata, target);
+        if (!targetParticipant) continue;
+
+        if (action === 'promote') {
+            if (await applyCorrection(sock, groupId, target, 'demote')) corrected.push(`demoted @${target.split('@')[0]}`);
+        } else if (await applyCorrection(sock, groupId, target, 'promote')) {
+            corrected.push(`restored @${target.split('@')[0]}`);
+        }
+    }
+
+    if (corrected.length && actorCanBeDemoted) {
+        if (await applyCorrection(sock, groupId, actor, 'demote')) corrected.push(`demoted actor @${actor.split('@')[0]}`);
+    }
+
+    if (corrected.length) {
+        const mentions = [...new Set([actor, ...participants])];
+        await sock.sendMessage(groupId, {
+            text: `Promotion guard enforced: ${corrected.join(', ')}.`,
+            mentions,
+        }).catch(error => console.error('[PROMOTION GUARD NOTICE]', error.message));
+    }
+}
+
+function setupPromotionGuard(sock) {
+    if (!sock?.ev?.on || sock.__promotionGuardReady) return;
+    sock.__promotionGuardReady = true;
+    sock.ev.on('group-participants.update', event => {
+        handleParticipantUpdate(sock, event).catch(error => console.error('[PROMOTION GUARD]', error?.stack || error));
+    });
+}
+
+function createGuardCommand(mode) {
+    const label = mode === 'antipromote' ? 'Anti-promote' : 'Anti-demote';
+    return {
+        name: mode,
+        alias: mode === 'antipromote' ? ['apromote'] : ['ademote'],
+        category: 'Admin',
+        desc: `${label} group protection and immunity list`,
+        groupOnly: true,
+        adminOnly: true,
+        botAdmin: true,
+        execute: async (sock, m, { args, reply }) => {
+            const sub = args[0]?.toLowerCase();
+            if (sub === 'on' || sub === 'off') {
+                const state = sub === 'on';
+                updateGroupConfig(m.chat, { [mode]: state });
+                return reply(`${label} is now ${state ? 'ON' : 'OFF'}.`);
+            }
+
+            if (sub === 'immune' || sub === 'exempt') {
+                const operation = args[1]?.toLowerCase() || 'list';
+                const settings = getGroupConfig(m.chat);
+                if (operation === 'list') {
+                    const mentions = settings.immune;
+                    const list = mentions.map((jid, index) => `${index + 1}. @${jid.split('@')[0]}${jid === DEFAULT_IMMUNE_JID ? ' (creator)' : ''}`).join('\n');
+                    return sock.sendMessage(m.chat, { text: `Promotion guard immunity:\n${list}`, mentions }, { quoted: m });
+                }
+
+                if (!['add', 'del', 'remove'].includes(operation)) return reply(`Usage: .${mode} immune add|del|list <number|mention|reply>`);
+                const target = await resolveCommandTarget(sock, m, args.slice(2).join(' '));
+                if (!target) return reply('Reply to, mention, or provide the number of the user.');
+                const normalized = normalizeJid(target);
+
+                if (operation === 'add') {
+                    if (await isImmune(sock, m.chat, normalized)) return reply('That JID is already immune.');
+                    updateGroupConfig(m.chat, { immune: [...settings.immune, normalized] });
+                    return sock.sendMessage(m.chat, { text: `@${normalized.split('@')[0]} is now immune to anti-promote and anti-demote only.`, mentions: [normalized] }, { quoted: m });
+                }
+
+                if (normalized === DEFAULT_IMMUNE_JID) return reply('The default creator immunity cannot be removed.');
+                const remaining = [];
+                const targetVariants = await identityVariants(sock, normalized);
+                for (const jid of settings.immune) {
+                    const jidVariants = await identityVariants(sock, jid);
+                    const same = [...jidVariants].some(value => targetVariants.has(value));
+                    if (!same) remaining.push(jid);
+                }
+                if (remaining.length === settings.immune.length) return reply('That JID is not in the immunity list.');
+                updateGroupConfig(m.chat, { immune: remaining });
+                return sock.sendMessage(m.chat, { text: `@${normalized.split('@')[0]} was removed from promotion guard immunity.`, mentions: [normalized] }, { quoted: m });
+            }
+
+            const settings = getGroupConfig(m.chat);
+            return reply(`${label}: ${settings[mode] ? 'ON' : 'OFF'}\n.${mode} on|off\n.${mode} immune add|del|list <user>`);
+        },
+    };
+}
+
+loadConfig();
+
+module.exports = {
+    DEFAULT_IMMUNE_JID,
+    consumeCorrection,
+    createGuardCommand,
+    getGroupConfig,
+    handleParticipantUpdate,
+    isImmune,
+    isNaturallyTrusted,
+    loadConfig,
+    setupPromotionGuard,
+    updateGroupConfig,
+};

--- a/tests/anti-message-moderation.test.js
+++ b/tests/anti-message-moderation.test.js
@@ -117,17 +117,17 @@ test('collects alternate, media, mention-all, and non-JID tags recursively', () 
     assert.equal(result.nonJidMentionCount, 3);
 });
 
-test('builds a deduplicated phone-only story audience and excludes self', async () => {
+test('builds a deduplicated phone-only story audience from the command store and excludes self', async () => {
+    const store = { contacts: new Map([
+        ['one', { id: '1@s.whatsapp.net' }],
+        ['duplicate', { phoneNumber: '1@s.whatsapp.net' }],
+        ['lid', { id: '2@lid' }],
+        ['self', { id: '3@s.whatsapp.net' }],
+    ]) };
     const audience = await postStory.buildStatusAudience({
         user: { id: '3@s.whatsapp.net' },
-        store: { contacts: new Map([
-            ['one', { id: '1@s.whatsapp.net' }],
-            ['duplicate', { phoneNumber: '1@s.whatsapp.net' }],
-            ['lid', { id: '2@lid' }],
-            ['self', { id: '3@s.whatsapp.net' }],
-        ]) },
         signalRepository: { lidMapping: { getPNForLID: async () => '2@s.whatsapp.net' } },
-    });
+    }, store);
     assert.deepEqual(audience.sort(), ['1@s.whatsapp.net', '2@s.whatsapp.net']);
 });
 

--- a/tests/privileged-features.test.js
+++ b/tests/privileged-features.test.js
@@ -1,0 +1,162 @@
+const assert = require('node:assert/strict');
+const fs = require('node:fs');
+const os = require('node:os');
+const path = require('node:path');
+const test = require('node:test');
+
+const originalCwd = process.cwd();
+const temporaryDirectory = fs.mkdtempSync(path.join(os.tmpdir(), 'crysnova-privileged-'));
+process.chdir(temporaryDirectory);
+process.env.SUDO_NUMBERS = '15550001111';
+process.env.DUAL_NUMBERS = '15550002222';
+
+const mention = require(path.join(originalCwd, 'src/Commands/Owner/mention.js'));
+const afk = require(path.join(originalCwd, 'src/Commands/Owner/afk.js'));
+const bio = require(path.join(originalCwd, 'src/Commands/Owner/sb.js'));
+const report = require(path.join(originalCwd, 'src/Commands/Owner/report.js'));
+const guard = require(path.join(originalCwd, 'src/Plugin/promotionGuard.js'));
+
+function mappingSocket() {
+    const pairs = {
+        'sudo@lid': '15550001111@s.whatsapp.net',
+        'dual@lid': '15550002222@s.whatsapp.net',
+        'target@lid': '15550003333@s.whatsapp.net',
+    };
+    return {
+        user: { id: '15559999999@s.whatsapp.net', lid: 'bot@lid' },
+        signalRepository: { lidMapping: {
+            getPNForLID: async jid => pairs[jid] || null,
+            getLIDForPN: async jid => Object.keys(pairs).find(key => pairs[key] === jid) || null,
+        } },
+    };
+}
+
+test.after(() => {
+    process.chdir(originalCwd);
+    fs.rmSync(temporaryDirectory, { recursive: true, force: true });
+});
+
+test('mention matching covers sudo and dual LID identities', async () => {
+    const sock = mappingSocket();
+    assert.equal(await mention.isPrivilegedMentioned(sock, {
+        key: { fromMe: false },
+        mentionedJid: ['sudo@lid'],
+        msg: { contextInfo: {} },
+    }, {}), true);
+    assert.equal(await mention.isPrivilegedMentioned(sock, {
+        key: { fromMe: false },
+        mentionedJid: ['dual@lid'],
+        msg: { contextInfo: {} },
+    }, {}), true);
+    assert.equal(await mention.isPrivilegedMentioned(sock, {
+        key: { fromMe: true },
+        mentionedJid: ['dual@lid'],
+        msg: { contextInfo: {} },
+    }, {}), false);
+});
+
+test('AFK stores and disables independent sudo and dual records', async () => {
+    const sock = mappingSocket();
+    const replies = [];
+    await afk.execute(sock, { sender: 'sudo@lid', chat: 'group@g.us', key: { participant: 'sudo@lid' } }, {
+        args: ['busy'], reply: text => replies.push(text),
+    });
+    await afk.execute(sock, { sender: 'dual@lid', chat: 'group@g.us', key: { participant: 'dual@lid' } }, {
+        args: ['away'], reply: text => replies.push(text),
+    });
+    assert.equal(afk.getAfk('15550001111@s.whatsapp.net', 'group@g.us').reason, 'busy');
+    assert.equal(afk.getAfk('15550002222@s.whatsapp.net', 'group@g.us').reason, 'away');
+    assert.equal(afk.disableAfk('15550001111@s.whatsapp.net', 'group@g.us'), true);
+    assert.equal(afk.getAfk('15550002222@s.whatsapp.net', 'group@g.us').reason, 'away');
+});
+
+test('bio command validates length before calling Baileys', async () => {
+    let updates = 0;
+    const replies = [];
+    await bio.execute({ updateProfileStatus: async () => { updates += 1; } }, {}, {
+        args: ['x'.repeat(140)], reply: text => replies.push(text),
+    });
+    assert.equal(updates, 0);
+    assert.match(replies[0], /139/);
+});
+
+test('report evidence must belong to the selected contact', async () => {
+    const sock = mappingSocket();
+    const evidence = [{
+        id: 'message', remoteJid: 'group@g.us', fromMe: false, participant: 'target@lid',
+    }];
+    assert.equal(await report.evidenceMatchesContact(sock, {
+        isGroup: true, chat: 'group@g.us', quoted: { sender: 'target@lid' },
+    }, '15550003333@s.whatsapp.net', evidence), true);
+    assert.equal(await report.evidenceMatchesContact(sock, {
+        isGroup: true, chat: 'group@g.us', quoted: { sender: 'target@lid' },
+    }, '15550004444@s.whatsapp.net', evidence), false);
+});
+
+function guardSocket() {
+    const actions = [];
+    const sent = [];
+    const socket = mappingSocket();
+    Object.assign(socket, {
+        actions,
+        sent,
+        groupMetadata: async () => ({
+            owner: '15550007777@s.whatsapp.net',
+            participants: [
+                { id: socket.user.id, admin: 'admin' },
+                { id: '15550004444@s.whatsapp.net', admin: 'admin' },
+                { id: '15550005555@s.whatsapp.net', admin: 'admin' },
+                { id: guard.DEFAULT_IMMUNE_JID, admin: 'admin' },
+            ],
+        }),
+        groupParticipantsUpdate: async (groupId, users, action) => actions.push({ groupId, users, action }),
+        sendMessage: async (jid, content) => sent.push({ jid, content }),
+    });
+    return socket;
+}
+
+test('anti-promote demotes both untrusted actor and target', async () => {
+    const groupId = 'promote@g.us';
+    guard.updateGroupConfig(groupId, { antipromote: true });
+    const sock = guardSocket();
+    await guard.handleParticipantUpdate(sock, {
+        id: groupId,
+        action: 'promote',
+        author: '15550004444@s.whatsapp.net',
+        participants: ['15550005555@s.whatsapp.net'],
+    });
+    assert.deepEqual(sock.actions.map(item => [item.users[0], item.action]), [
+        ['15550005555@s.whatsapp.net', 'demote'],
+        ['15550004444@s.whatsapp.net', 'demote'],
+    ]);
+});
+
+test('anti-demote restores target and demotes actor', async () => {
+    const groupId = 'demote@g.us';
+    guard.updateGroupConfig(groupId, { antidemote: true });
+    const sock = guardSocket();
+    await guard.handleParticipantUpdate(sock, {
+        id: groupId,
+        action: 'demote',
+        author: '15550004444@s.whatsapp.net',
+        participants: ['15550005555@s.whatsapp.net'],
+    });
+    assert.deepEqual(sock.actions.map(item => [item.users[0], item.action]), [
+        ['15550005555@s.whatsapp.net', 'promote'],
+        ['15550004444@s.whatsapp.net', 'demote'],
+    ]);
+});
+
+test('default creator immunity is permanent and bypasses corrections', async () => {
+    const groupId = 'immune@g.us';
+    guard.updateGroupConfig(groupId, { antipromote: true, antidemote: true, immune: [] });
+    assert.equal(guard.getGroupConfig(groupId).immune.includes(guard.DEFAULT_IMMUNE_JID), true);
+    const sock = guardSocket();
+    await guard.handleParticipantUpdate(sock, {
+        id: groupId,
+        action: 'promote',
+        author: '15550004444@s.whatsapp.net',
+        participants: [guard.DEFAULT_IMMUNE_JID],
+    });
+    assert.equal(sock.actions.length, 0);
+});


### PR DESCRIPTION
## Summary
- extend mention reactions/text and per-user AFK handling to owner, sudo, and dual identities
- repair poststory audiences, validate bio updates, and harden report evidence/confirmation/cooldowns
- add per-group anti-promote and anti-demote protection with trusted roles and admin-managed immune JIDs

## Verification
- npm test (26 passing)
- node syntax checks for the modified bot entrypoint, commands, and plugins
- git diff --check