### PR TITLE
Fix mention reactions on replies

### DIFF
--- a/src/Commands/Owner/mention.js
+++ b/src/Commands/Owner/mention.js
@@ -59,13 +59,12 @@ async function getPrivilegedIdentities(sock) {
 async function isPrivilegedMentioned(sock, m, mek) {
     if (m.key?.fromMe) return false;
     const context = getContextInfo(m);
+    // Only explicit @tags count. Reply metadata (participant/quoted sender)
+    // must not trigger the configured mention response.
     const mentions = [...new Set([
         ...(context.mentionedJid || []),
         ...(m.mentionedJid || []),
         ...(m.msg?.contextInfo?.mentionedJid || []),
-        context.participant,
-        context.participantAlt,
-        m.quoted?.sender,
     ].filter(Boolean))];
     if (!mentions.length) return false;
 

--- a/tests/privileged-features.test.js
+++ b/tests/privileged-features.test.js
@@ -55,6 +55,20 @@ test('mention matching covers sudo and dual LID identities', async () => {
     }, {}), false);
 });
 
+test('mention matching ignores replies without an explicit tag', async () => {
+    const sock = mappingSocket();
+    assert.equal(await mention.isPrivilegedMentioned(sock, {
+        key: { fromMe: false },
+        quoted: { sender: 'sudo@lid' },
+        msg: {
+            contextInfo: {
+                participant: 'sudo@lid',
+                participantAlt: '15550001111@s.whatsapp.net',
+            },
+        },
+    }, {}), false);
+});
+
 test('AFK stores and disables independent sudo and dual records', async () => {
     const sock = mappingSocket();
     const replies = [];


### PR DESCRIPTION
## Summary
- trigger configured mention reactions/text only for explicit @tags
- ignore quoted-message and reply participant metadata for owner, sudo, and dual users
- add regression coverage for replies without explicit tags

## Verification
- npm test
- node syntax check
- git diff --check