### PR TITLE
Make anti-promote/anti-demote actively enforce and fix sudo/dual @lid replies

### DIFF
--- a/src/Plugin/identityUtils.js
+++ b/src/Plugin/identityUtils.js
@@ -11,12 +11,32 @@ async function resolvePhoneJid(sock, candidates = []) {
     if (mapper?.getPNForLID) {
         for (const jid of values.filter(value => value.endsWith('@lid'))) {
             try {
-                const mapped = await mapper.getPNForLID(jid);
-                if (mapped) return normalizeJid(mapped);
+                const mapped = normalizeJid(await mapper.getPNForLID(jid) || '');
+                if (isPhoneJid(mapped)) return mapped;
             } catch {}
         }
     }
 
+    return null;
+}
+
+async function resolvePhoneJidWithMetadata(sock, chatId, candidates = []) {
+    const direct = await resolvePhoneJid(sock, candidates);
+    if (direct) return direct;
+
+    if (!String(chatId).endsWith('@g.us')) return null;
+    const metadata = await sock.groupMetadata?.(chatId)?.catch?.(() => null) || null;
+    if (!metadata?.participants) return null;
+
+    const wanted = new Set(candidates.filter(Boolean).map(normalizeJid));
+    for (const participant of metadata.participants) {
+        const ids = [participant.id, participant.lid, participant.jid].filter(Boolean).map(normalizeJid);
+        if (ids.some(jid => wanted.has(jid))) {
+            const phone = [participant.phoneNumber, participant.id, participant.jid]
+                .filter(Boolean).map(normalizeJid).find(isPhoneJid);
+            if (phone) return phone;
+        }
+    }
     return null;
 }
 
@@ -68,7 +88,7 @@ async function resolveCommandTarget(sock, m, rawValue = '') {
         contextInfo.participant,
     ];
 
-    return resolvePhoneJid(sock, candidates);
+    return resolvePhoneJidWithMetadata(sock, m?.chat, candidates);
 }
 
 module.exports = {
@@ -80,4 +100,5 @@ module.exports = {
     normalizeJid,
     resolveCommandTarget,
     resolvePhoneJid,
+    resolvePhoneJidWithMetadata,
 };

--- a/src/Plugin/promotionGuard.js
+++ b/src/Plugin/promotionGuard.js
@@ -77,17 +77,6 @@ async function isNaturallyTrusted(sock, metadata, jid) {
     return [...candidate].some(value => trustedVariants.has(normalizeJid(value)));
 }
 
-function participantJids(participant = {}) {
-    return [participant.id, participant.phoneNumber, participant.lid].filter(Boolean).map(normalizeJid);
-}
-
-async function findParticipant(sock, metadata, jid) {
-    const target = await identityVariants(sock, jid);
-    return (metadata?.participants || []).find(participant =>
-        participantJids(participant).some(value => target.has(value))
-    ) || null;
-}
-
 function correctionKey(groupId, action, jid) {
     return `${groupId}:${action}:${normalizeJid(jid)}`;
 }
@@ -125,28 +114,32 @@ async function handleParticipantUpdate(sock, event) {
     if ((action === 'promote' && !settings.antipromote) || (action === 'demote' && !settings.antidemote)) return;
 
     const participants = (event.participants || []).map(normalizeJid).filter(Boolean);
-    if (participants.length && participants.every(jid => consumeCorrection(groupId, action, jid))) return;
+    if (!participants.length) return;
 
-    const actor = normalizeJid(event.author || event.actor || event.participant || '');
-    if (!actor) return;
+    // Skip only events that are entirely the bot's own corrections.
+    const pending = participants.filter(jid => !consumeCorrection(groupId, action, jid));
+    if (!pending.length) return;
 
     const metadata = await sock.groupMetadata(groupId).catch(() => null);
     if (!metadata) return;
-    const bot = await findParticipant(sock, metadata, sock.user?.id || '');
-    if (!bot?.admin) return;
-    if (await isNaturallyTrusted(sock, metadata, actor) || await isImmune(sock, groupId, actor)) return;
 
-    const actorParticipant = await findParticipant(sock, metadata, actor);
-    const actorCanBeDemoted = Boolean(actorParticipant?.admin)
-        && !(await isNaturallyTrusted(sock, metadata, actor))
-        && !(await isImmune(sock, groupId, actor));
+    const actor = normalizeJid(event.author || event.actor || '');
+    const botJids = await variantsForMany(sock, [sock.user?.id, sock.user?.lid].filter(Boolean));
+
+    // The bot's own actions (including corrections) are never punished.
+    if (actor && botJids.has(normalizeJid(actor))) return;
+
+    let actorIsTrusted = false;
+    if (actor) {
+        actorIsTrusted = await isNaturallyTrusted(sock, metadata, actor) || await isImmune(sock, groupId, actor);
+        if (actorIsTrusted) return;
+    }
+
     const corrected = [];
 
-    for (const target of participants) {
-        if (consumeCorrection(groupId, action, target)) continue;
+    for (const target of pending) {
+        if (botJids.has(normalizeJid(target))) continue;
         if (await isNaturallyTrusted(sock, metadata, target) || await isImmune(sock, groupId, target)) continue;
-        const targetParticipant = await findParticipant(sock, metadata, target);
-        if (!targetParticipant) continue;
 
         if (action === 'promote') {
             if (await applyCorrection(sock, groupId, target, 'demote')) corrected.push(`demoted @${target.split('@')[0]}`);
@@ -155,12 +148,12 @@ async function handleParticipantUpdate(sock, event) {
         }
     }
 
-    if (corrected.length && actorCanBeDemoted) {
+    if (corrected.length && actor) {
         if (await applyCorrection(sock, groupId, actor, 'demote')) corrected.push(`demoted actor @${actor.split('@')[0]}`);
     }
 
     if (corrected.length) {
-        const mentions = [...new Set([actor, ...participants])];
+        const mentions = [...new Set([actor, ...participants].filter(Boolean))];
         await sock.sendMessage(groupId, {
             text: `Promotion guard enforced: ${corrected.join(', ')}.`,
             mentions,

--- a/tests/privileged-features.test.js
+++ b/tests/privileged-features.test.js
@@ -107,6 +107,22 @@ test('report evidence must belong to the selected contact', async () => {
     }, '15550004444@s.whatsapp.net', evidence), false);
 });
 
+test('access list target resolution returns a phone JID for unmapped LID mentions', async () => {
+    const identity = require(path.join(originalCwd, 'src/Plugin/identityUtils.js'));
+    const sock = mappingSocket();
+    sock.groupMetadata = async () => ({
+        participants: [
+            { id: 'unmapped@lid', phoneNumber: '15550006666@s.whatsapp.net' },
+        ],
+    });
+    const resolved = await identity.resolveCommandTarget(sock, {
+        chat: 'group@g.us',
+        mentionedJid: ['unmapped@lid'],
+        msg: { contextInfo: {} },
+    }, '');
+    assert.equal(resolved, '15550006666@s.whatsapp.net');
+});
+
 function guardSocket() {
     const actions = [];
     const sent = [];
@@ -159,6 +175,41 @@ test('anti-demote restores target and demotes actor', async () => {
         ['15550005555@s.whatsapp.net', 'promote'],
         ['15550004444@s.whatsapp.net', 'demote'],
     ]);
+});
+
+test('anti-promote still enforces when the bot is missing from stale metadata', async () => {
+    const groupId = 'stale@g.us';
+    guard.updateGroupConfig(groupId, { antipromote: true });
+    const sock = guardSocket();
+    sock.groupMetadata = async () => ({
+        owner: '15550007777@s.whatsapp.net',
+        participants: [
+            { id: '15550004444@s.whatsapp.net', admin: 'admin' },
+        ],
+    });
+    await guard.handleParticipantUpdate(sock, {
+        id: groupId,
+        action: 'promote',
+        author: '15550004444@s.whatsapp.net',
+        participants: ['15550005555@s.whatsapp.net'],
+    });
+    assert.deepEqual(sock.actions.map(item => [item.users[0], item.action]), [
+        ['15550005555@s.whatsapp.net', 'demote'],
+        ['15550004444@s.whatsapp.net', 'demote'],
+    ]);
+});
+
+test('promotion guard ignores events performed by the bot itself', async () => {
+    const groupId = 'botself@g.us';
+    guard.updateGroupConfig(groupId, { antipromote: true });
+    const sock = guardSocket();
+    await guard.handleParticipantUpdate(sock, {
+        id: groupId,
+        action: 'promote',
+        author: sock.user.id,
+        participants: ['15550005555@s.whatsapp.net'],
+    });
+    assert.equal(sock.actions.length, 0);
 });
 
 test('default creator immunity is permanent and bypasses corrections', async () => {


### PR DESCRIPTION
## Summary
- remove the bot-admin metadata precheck that silently blocked anti-promote/anti-demote enforcement when group metadata was stale
- always demote both the untrusted actor and target (or restore the demoted target) as soon as the participant-update event arrives, skipping only the bot's own corrective actions
- resolve unmapped @lid mentions to real phone JIDs via group metadata so `.sudo add @user` and `.dual add @user` reply with @number instead of @lid

## Verification
- npm test (30 passing)
- node syntax checks on promotionGuard.js and identityUtils.js
- git diff --check