### PR TITLE
Fix promotion guard enforcement and add device command

### DIFF
--- a/src/Commands/Tools/device.js
+++ b/src/Commands/Tools/device.js
@@ -1,0 +1,54 @@
+const DEVICE_LABELS = {
+    ios: 'iPhone (iOS)',
+    android: 'Android',
+    web: 'WhatsApp Web',
+    desktop: 'WhatsApp Desktop',
+    unknown: 'Unknown device',
+};
+
+function detectDevice(messageId) {
+    try {
+        const { getDevice } = require('@crysnovax/baileys');
+        if (typeof getDevice === 'function') return getDevice(messageId);
+    } catch {}
+    // Fallback: same prediction rules Baileys uses internally.
+    const id = String(messageId || '');
+    if (/^3A.{18}$/.test(id)) return 'ios';
+    if (/^3E.{20}$/.test(id)) return 'web';
+    if (/^(.{21}|.{32})$/.test(id)) return 'android';
+    if (/^(3F|.{18}$)/.test(id)) return 'desktop';
+    return 'unknown';
+}
+
+module.exports = {
+    name: 'device',
+    alias: ['checkdevice', 'dev'],
+    desc: 'Detect the device a message was sent from',
+    category: 'Tools',
+    usage: '.device (reply to a message)',
+    reactions: { start: '📱', success: '✅', error: '❌' },
+
+    execute: async (sock, m, { reply }) => {
+        const quotedId = m.quoted?.key?.id || m.quoted?.id
+            || m.msg?.contextInfo?.stanzaId
+            || m.message?.extendedTextMessage?.contextInfo?.stanzaId;
+
+        const targetId = quotedId || m.key?.id;
+        const targetSender = quotedId
+            ? (m.quoted?.sender || m.msg?.contextInfo?.participant || 'that user')
+            : (m.sender || 'you');
+
+        if (!targetId) return reply('Could not read a message ID. Reply to a message with .device');
+
+        const device = detectDevice(targetId);
+        const label = DEVICE_LABELS[device] || DEVICE_LABELS.unknown;
+        const who = quotedId ? `@${String(targetSender).split('@')[0]}` : 'You';
+
+        return sock.sendMessage(m.chat, {
+            text: `📱 *Device Check*\n\n${who} sent that message from: *${label}*\n\n_Prediction is based on the WhatsApp message ID pattern._`,
+            mentions: quotedId && String(targetSender).includes('@') ? [targetSender] : [],
+        }, { quoted: m });
+    },
+
+    detectDevice,
+};

--- a/src/Plugin/promotionGuard.js
+++ b/src/Plugin/promotionGuard.js
@@ -45,6 +45,15 @@ function updateGroupConfig(groupId, updates) {
     return getGroupConfig(groupId);
 }
 
+// Baileys emits participants either as JID strings or as parsed objects
+// ({ phoneNumber, lid, jid, id }). Normalise both shapes to a JID string.
+function extractJid(entry) {
+    if (!entry) return '';
+    if (typeof entry === 'string') return normalizeJid(entry);
+    const candidate = entry.phoneNumber || entry.jid || entry.id || entry.lid || entry.pn || '';
+    return normalizeJid(candidate);
+}
+
 async function variantsForMany(sock, jids) {
     const variants = new Set();
     for (const jid of jids.filter(Boolean)) {
@@ -113,7 +122,7 @@ async function handleParticipantUpdate(sock, event) {
     const settings = getGroupConfig(groupId);
     if ((action === 'promote' && !settings.antipromote) || (action === 'demote' && !settings.antidemote)) return;
 
-    const participants = (event.participants || []).map(normalizeJid).filter(Boolean);
+    const participants = (event.participants || []).map(extractJid).filter(Boolean);
     if (!participants.length) return;
 
     // Skip only events that are entirely the bot's own corrections.
@@ -121,9 +130,8 @@ async function handleParticipantUpdate(sock, event) {
     if (!pending.length) return;
 
     const metadata = await sock.groupMetadata(groupId).catch(() => null);
-    if (!metadata) return;
 
-    const actor = normalizeJid(event.author || event.actor || '');
+    const actor = extractJid(event.authorPn || event.author || event.actor || '');
     const botJids = await variantsForMany(sock, [sock.user?.id, sock.user?.lid].filter(Boolean));
 
     // The bot's own actions (including corrections) are never punished.

--- a/tests/privileged-features.test.js
+++ b/tests/privileged-features.test.js
@@ -212,6 +212,63 @@ test('promotion guard ignores events performed by the bot itself', async () => {
     assert.equal(sock.actions.length, 0);
 });
 
+test('anti-promote handles real Baileys object-shaped participants and LID author', async () => {
+    const groupId = 'objects@g.us';
+    guard.updateGroupConfig(groupId, { antipromote: true });
+    const sock = guardSocket();
+    await guard.handleParticipantUpdate(sock, {
+        id: groupId,
+        action: 'promote',
+        author: 'actor@lid',
+        authorPn: '15550004444@s.whatsapp.net',
+        participants: [{ phoneNumber: '15550005555@s.whatsapp.net', lid: 'target@lid' }],
+    });
+    assert.deepEqual(sock.actions.map(item => [item.users[0], item.action]), [
+        ['15550005555@s.whatsapp.net', 'demote'],
+        ['15550004444@s.whatsapp.net', 'demote'],
+    ]);
+});
+
+test('anti-demote handles object-shaped participants with lid only', async () => {
+    const groupId = 'lidonly@g.us';
+    guard.updateGroupConfig(groupId, { antidemote: true });
+    const sock = guardSocket();
+    await guard.handleParticipantUpdate(sock, {
+        id: groupId,
+        action: 'demote',
+        author: '15550004444@s.whatsapp.net',
+        participants: [{ lid: 'victim@lid' }],
+    });
+    assert.deepEqual(sock.actions.map(item => [item.users[0], item.action]), [
+        ['victim@lid', 'promote'],
+        ['15550004444@s.whatsapp.net', 'demote'],
+    ]);
+});
+
+test('promotion guard enforces even when group metadata fetch fails', async () => {
+    const groupId = 'nometa@g.us';
+    guard.updateGroupConfig(groupId, { antipromote: true });
+    const sock = guardSocket();
+    sock.groupMetadata = async () => { throw new Error('metadata unavailable'); };
+    await guard.handleParticipantUpdate(sock, {
+        id: groupId,
+        action: 'promote',
+        author: '15550004444@s.whatsapp.net',
+        participants: [{ phoneNumber: '15550005555@s.whatsapp.net' }],
+    });
+    assert.deepEqual(sock.actions.map(item => [item.users[0], item.action]), [
+        ['15550005555@s.whatsapp.net', 'demote'],
+        ['15550004444@s.whatsapp.net', 'demote'],
+    ]);
+});
+
+test('device command predicts device from message ID patterns', () => {
+    const device = require(path.join(originalCwd, 'src/Commands/Tools/device.js'));
+    assert.equal(device.detectDevice('3A123456789012345678'), 'ios');
+    assert.equal(device.detectDevice('3EB0123456789ABCDEF012'), 'web');
+    assert.equal(device.detectDevice('A1B2C3D4E5F6G7H8I9J0K'), 'android');
+});
+
 test('default creator immunity is permanent and bypasses corrections', async () => {
     const groupId = 'immune@g.us';
     guard.updateGroupConfig(groupId, { antipromote: true, antidemote: true, immune: [] });


### PR DESCRIPTION
## Summary
- fix the root cause: this Baileys fork emits participant-update entries as parsed objects ({ phoneNumber, lid, jid }), not JID strings. The guard was calling normalizeJid on the object and producing "[object Object]", so no actor/target ever matched and nobody was demoted.
- add extractJid() to normalise both string and object shapes, and read the LID author's phone via authorPn.
- guard now enforces even when groupMetadata is unavailable: on anti-promote it demotes BOTH the acting admin and the newly promoted member; on anti-demote it restores the target's admin and demotes the actor.
- add a .device command that predicts a chat/replied message's device (android/ios/web/desktop) from WhatsApp message-ID patterns.

## Verification
- npm test (34 passing), including object-shaped events, LID-only participants, metadata-failure enforcement, and device detection
- node syntax checks on promotionGuard.js and device.js
- git diff --check