### PR TITLE
fix: correct 1-hour uptime offset and implement ssd toggle

### DIFF
--- a/src/Commands/Bot/uptime.js
+++ b/src/Commands/Bot/uptime.js
@@ -15,7 +15,10 @@ module.exports = {
             
             try {
                 const { data } = await getTimeData(timezone);
-                currentTime = new Date(data.datetime).toLocaleTimeString('en-US', {
+                const time = new Date(data.datetime);
+                // Subtract 1 hour to correct API time offset
+                time.setHours(time.getHours() - 1);
+                currentTime = time.toLocaleTimeString('en-US', {
                     hour: 'numeric',
                     minute: '2-digit',
                     hour12: true,

--- a/src/Commands/Owner/ssd.js
+++ b/src/Commands/Owner/ssd.js
@@ -1,0 +1,56 @@
+const fs = require('fs');
+const path = require('path');
+
+module.exports = {
+    name: 'ssd',
+    alias: ['secureservice', 'ssdon', 'ssdoff'],
+    desc: 'Toggle Meta Secure Server-side Data service',
+    category: 'Owner',
+    reactions: { start: '🔒', success: '✅' },
+    ownerOnly: true,
+    groupOnly: false,
+
+    execute: async (sock, m, { args, reply }) => {
+        try {
+            const mainFile = path.join(__dirname, '../../?.js');
+            
+            if (!fs.existsSync(mainFile)) {
+                return reply('⚠ Main file not found');
+            }
+
+            let content = fs.readFileSync(mainFile, 'utf8');
+            
+            // Check current state
+            const isCurrentlyEnabled = /content\.secureMetaServiceLabel\s*=\s*true/.test(content);
+            
+            // Toggle: if enabled, set to false; if disabled, set to true
+            if (isCurrentlyEnabled) {
+                // Turn OFF
+                content = content.replace(
+                    /content\.secureMetaServiceLabel\s*=\s*true/g,
+                    'content.secureMetaServiceLabel = false'
+                );
+                fs.writeFileSync(mainFile, content, 'utf8');
+                return reply('🔒 *SSD:* Toggled *OFF*');
+            } else {
+                // Turn ON
+                content = content.replace(
+                    /content\.secureMetaServiceLabel\s*=\s*false/g,
+                    'content.secureMetaServiceLabel = true'
+                );
+                // If line doesn't exist, add it
+                if (!content.includes('content.secureMetaServiceLabel')) {
+                    content = content.replace(
+                        /content\.ai\s*=\s*true/,
+                        'content.ai = true;\n        content.secureMetaServiceLabel = true'
+                    );
+                }
+                fs.writeFileSync(mainFile, content, 'utf8');
+                return reply('🔒 *SSD:* Toggled *ON*');
+            }
+        } catch (err) {
+            console.error('[SSD ERROR]', err);
+            reply('⚠ Error toggling SSD');
+        }
+    }
+};


### PR DESCRIPTION
## Uptime Time Fix & SSD Toggle

### Uptime Fix
- **Issue**: Time was 1 hour faster (ahead by 1 hour)
- **Solution**: Subtract 1 hour from API response in uptime.js
- **Result**: Time now displays accurately with correct offset

### SSD Toggle Command
- **New command**: `.ssd` - Toggle Meta Secure Server-side Data service
- **Functionality**: Toggles `content.secureMetaServiceLabel` in ?.js between true/false
- **Response**: Simple reply - 'SSD: Toggled ON' or 'SSD: Toggled OFF'
- **Protection**: Owner-only command

Both fixes are minimal, focused, and maintain original behavior while correcting the identified issues.

Co-authored-by: v0 <it+v0agent@vercel.com>