### PR TITLE
fix: correct undefined modetoUpperCase error in mode command

### DIFF
--- a/src/Commands/Owner/mode.js
+++ b/src/Commands/Owner/mode.js
@@ -21,7 +21,7 @@ module.exports = {
         // 2. Persist to runtime-config.json so it survives restarts
         setVar('PUBLIC_MODE', isPublic);
 
-        reply(`${prefix}_*❏◦SET TO ${modetoUpperCase()} 彡*_`);
+        reply(`*❏◦SET TO ${mode.toUpperCase()} 彡*`);
     }
 };
 


### PR DESCRIPTION
## Mode Command Fix

Fixed critical error: '[MSG ERROR] modetoUpperCase is not defined' when using .mode command.

### Changes
- Fixed typo: `modetoUpperCase()` → `mode.toUpperCase()`
- Removed undefined `prefix` variable from reply string
- Reply now returns simple format: 'SET TO PUBLIC/PRIVATE'

The mode command now works correctly when switching bot between public and private modes.

Co-authored-by: v0 <it+v0agent@vercel.com>