### PR TITLE
fix: apply runtime settings without restart

### DIFF
--- a/settings/config.js
+++ b/settings/config.js
@@ -171,7 +171,7 @@ const config = {
                 return (userPrefix === 'null' || userPrefix === '') ? '' : userPrefix;
             }
 
-            return '/';
+            return '.';
         })(),
 
         description: 'Professional WhatsApp Bot — ZEE BOT powered by CRYSNOVA AI V2',

--- a/src/Commands/System/setvar.js
+++ b/src/Commands/System/setvar.js
@@ -59,6 +59,34 @@ function writeEnv(map) {
     fs.writeFileSync(ENV_PATH, out.join('\n'));
 }
 
+function applyLiveConfig(config, key, value) {
+    if (config && typeof config === 'object') {
+        const paths = {
+            PREFIX: ['settings', 'prefix'],
+            BOT_NAME: ['settings', 'title'],
+            PUBLIC_MODE: ['status', 'public'],
+            TERMINAL_MODE: ['status', 'terminal'],
+            REACT_STATUS: ['status', 'reactsw'],
+            AUTO_READ: ['mode', 'autoRead'],
+            AUTO_TYPING: ['mode', 'autoTyping'],
+            AUTO_RECORDING: ['mode', 'autoRecording'],
+            ALWAYS_ONLINE: ['mode', 'alwaysOnline'],
+            SELF_BOT: ['mode', 'selfBot'],
+            OWNER_NAME: ['settings', 'ownerName'],
+            OWNER_JID: ['settings', 'ownerJid'],
+        };
+        const targetPath = paths[key];
+        if (targetPath) {
+            let target = config;
+            for (let i = 0; i < targetPath.length - 1; i++) target = target?.[targetPath[i]];
+            if (target) target[targetPath[targetPath.length - 1]] = value;
+        }
+        if (key === 'BOT_NAME') config.settings.packname = value;
+    }
+    // Several dependencies read process.env directly, so update this process too.
+    process.env[key] = String(value);
+}
+
 module.exports = {
     name: 'setvar',
     alias: ['sv'],
@@ -67,7 +95,7 @@ module.exports = {
     ownerOnly: true,
     reactions: { start: '⚙️', success: '👾' },
 
-    execute: async (sock, m, { args, reply }) => {
+    execute: async (sock, m, { args, reply, config }) => {
         if (!args[0]) return reply(
             `Usage: .setvar KEY=value\n\nExamples:\n` +
             `• .setvar PREFIX=.\n` +
@@ -91,8 +119,9 @@ module.exports = {
 
         if (!key || value === '') return reply('_*⚉ Usage:*_ `.setvar KEY=value`');
 
-        // 1. Save to runtime (immediate effect, no restart needed)
-        setVar(key, value);
+        // 1. Apply to the running bot immediately, then persist it.
+        const liveValue = setVar(key, value);
+        applyLiveConfig(config, key, liveValue);
 
         // 2. Save to .env (persists across restarts)
         try {

--- a/src/Plugin/crysLoadCmd.js
+++ b/src/Plugin/crysLoadCmd.js
@@ -8,7 +8,7 @@ const loadCommands = () => {
 
     // Initialize global prefix before loading commands so ${prefix} in usage fields works
     const { getVar } = require('./configManager');
-    global.prefix = require('../../settings/config').settings?.prefix ?? getVar('PREFIX', '/');
+    global.prefix = getVar('PREFIX', '.');
 
     clearRegistry();
 

--- a/src/Plugin/crysMsg.js
+++ b/src/Plugin/crysMsg.js
@@ -152,7 +152,7 @@ const handleMessage = async (sock, m, store) => {
         const cfg    = config();
 
         // ── PREFIX — supports null/empty for no-prefix mode ──
-        let prefix = cfg.settings?.prefix ?? getVar('PREFIX', '/');
+        let prefix = getVar('PREFIX', cfg.settings?.prefix ?? '.');
         if (prefix === 'null' || prefix === '') prefix = '';
 
         const autoReact    = getVar('AUTO_REACT', true);

--- a/⚉.js
+++ b/⚉.js
@@ -126,7 +126,8 @@ const clientstart = async () => {
     // Create socket
     const sock = makeWASocket({
         logger: pino({
-            level: process.env.LOG_LEVEL || 'info',
+            // Keep Baileys transport JSON out of hosted consoles by default; set LOG_LEVEL=info for protocol diagnostics.
+            level: process.env.LOG_LEVEL || 'silent',
             timestamp: pino.stdTimeFunctions.isoTime,
         }),
         printQRInTerminal: !getConfig().status.terminal,


### PR DESCRIPTION
## Summary
- restore `.` as the default command prefix
- make `.setvar` update the live config and process environment immediately
- suppress raw Baileys/Pino JSON logs by default while retaining clean application logs

## Validation
- `npm test`: 40/40 passing
- JavaScript syntax checks: passed
- `git diff --check`: passed

This is a follow-up to merged PR #91; the earlier PR was merged before this commit was pushed.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Configuration changes made with `setvar` now take effect immediately without restarting.
  * Nested settings, status, and mode values are updated live and persisted automatically.

* **Changes**
  * The default command prefix is now `.` instead of `/`.
  * Runtime prefix settings take priority over saved configuration.
  * Protocol logs are silent by default; set `LOG_LEVEL=info` to display them.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->