### PR TITLE
harden: the cloudflare worker proxy in worker in worker.js

### DIFF
--- a/worker.js
+++ b/worker.js
@@ -30,6 +30,12 @@ async function handle(request) {
 
   // Build target GitHub URL (strip /github prefix)
   const githubPath = url.pathname.replace(/^\/github/, '');
+
+  // Restrict to allowed GitHub API paths and prevent path traversal
+  if (!githubPath.startsWith('/repos/') || githubPath.includes('..')) {
+    return new Response('Forbidden', { status: 403 });
+  }
+
   const target = `https://api.github.com${githubPath}${url.search}`;
 
   // IMPORTANT: set your token in the Cloudflare Worker secrets as GITHUB_TOKEN


### PR DESCRIPTION
## Summary
Harden input handling in `worker.js` (flagged by multi_agent_ai).

## Vulnerability
| Field | Value |
|-------|-------|
| **ID** | V-003 |
| **Severity** | HIGH |
| **Scanner** | multi_agent_ai |
| **Rule** | `V-003` |
| **File** | `worker.js:37` |
| **Assessment** | Defensive hardening |

**Description**: The Cloudflare Worker proxy in worker.js strips the '/github' prefix from the request path and directly concatenates it into a GitHub API URL without any validation or sanitization. While the base URL is fixed to api.github.com, the attacker controls the full path and query string, allowing them to access any GitHub API endpoint using the server's GITHUB_TOKEN.

## Threat Model Context

This is a web service - vulnerabilities in request handlers are directly exploitable by remote attackers.

## Changes
- `worker.js`

## Behavior Preservation
The change is scoped to 1 file on the vulnerable path; it only tightens handling of untrusted input and leaves valid inputs unaffected.

---
*This patch removes an exploit primitive — a code pattern that, while not independently exploitable today, could be chained with other weaknesses by automated exploit-development tooling. Proactive removal of such primitives raises the bar against increasingly capable automated attack tools.*

---
*Automated security fix by [OrbisAI Security](https://orbisappsec.com)*


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Restricted GitHub API requests to approved repository paths.
  * Blocked unsafe or invalid paths with a 403 Forbidden response.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->